### PR TITLE
Do not use StateMachineName for cloudformation resource key names

### DIFF
--- a/lib/deploy/events/apiGateway/methods.test.js
+++ b/lib/deploy/events/apiGateway/methods.test.js
@@ -103,11 +103,11 @@ describe('#methods()', () => {
         .to.be.equal('StateMachineStepFunctionsStateMachine');
     });
 
-    it('should set custom stateMachinelogical ID to RequestTemplates when customName is set',
+    it('should set stateMachinelogical ID to RequestTemplates when customName is set',
     () => {
       expect(serverlessStepFunctions.getMethodIntegration('stateMachine', { name: 'custom' })
         .Properties.Integration.RequestTemplates['application/json']['Fn::Join'][1][2].Ref)
-        .to.be.equal('Custom');
+        .to.be.equal('StateMachineStepFunctionsStateMachine');
     });
 
     it('should set Access-Control-Allow-Origin header when cors is true',
@@ -138,12 +138,12 @@ describe('#methods()', () => {
         .to.be.equal('StateMachineStepFunctionsStateMachine');
     });
 
-    it('should set custom stateMachinelogical ID in default templates when customName is set',
+    it('should set stateMachinelogical ID in default templates when customName is set',
     () => {
       const requestTemplates = serverlessStepFunctions
         .getIntegrationRequestTemplates('stateMachine', { name: 'custom' });
       expect(requestTemplates['application/json']['Fn::Join'][1][2].Ref)
-        .to.be.equal('Custom');
+        .to.be.equal('StateMachineStepFunctionsStateMachine');
     });
 
     it('should return the default template for application/json when one is not given', () => {

--- a/lib/deploy/stepFunctions/compileStateMachines.test.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.test.js
@@ -39,44 +39,44 @@ describe('#compileStateMachines', () => {
 
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta1.Type
+      .MyStateMachine1StepFunctionsStateMachine.Type
     ).to.equal('AWS::StepFunctions::StateMachine');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta2.Type
+      .MyStateMachine2StepFunctionsStateMachine.Type
     ).to.equal('AWS::StepFunctions::StateMachine');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta1.Properties.DefinitionString
+      .MyStateMachine1StepFunctionsStateMachine.Properties.DefinitionString
     ).to.equal('"definition1"');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta2.Properties.DefinitionString
+      .MyStateMachine2StepFunctionsStateMachine.Properties.DefinitionString
     ).to.equal('"definition2"');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta1.Properties.RoleArn['Fn::GetAtt'][0]
+      .MyStateMachine1StepFunctionsStateMachine.Properties.RoleArn['Fn::GetAtt'][0]
     ).to.equal('IamRoleStateMachineExecution');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta2.Properties.RoleArn['Fn::GetAtt'][0]
+      .MyStateMachine2StepFunctionsStateMachine.Properties.RoleArn['Fn::GetAtt'][0]
     ).to.equal('IamRoleStateMachineExecution');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta1.DependsOn
+      .MyStateMachine1StepFunctionsStateMachine.DependsOn
     ).to.deep.eq(['IamRoleStateMachineExecution']);
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta2.DependsOn
+      .MyStateMachine2StepFunctionsStateMachine.DependsOn
     ).to.deep.eq(['IamRoleStateMachineExecution']);
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Outputs
-      .StateMachineBeta1Arn.Value.Ref
-    ).to.equal('StateMachineBeta1');
+      .MyStateMachine1StepFunctionsStateMachineArn.Value.Ref
+    ).to.equal('MyStateMachine1StepFunctionsStateMachine');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Outputs
-      .StateMachineBeta2Arn.Value.Ref
-    ).to.equal('StateMachineBeta2');
+      .MyStateMachine2StepFunctionsStateMachineArn.Value.Ref
+    ).to.equal('MyStateMachine2StepFunctionsStateMachine');
   });
 
   it('should create corresponding resources when definition property is given and no name', () => {
@@ -151,35 +151,35 @@ describe('#compileStateMachines', () => {
     serverlessStepFunctions.compileStateMachines();
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta1.Type
+      .MyStateMachine1StepFunctionsStateMachine.Type
     ).to.equal('AWS::StepFunctions::StateMachine');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta2.Type
+      .MyStateMachine2StepFunctionsStateMachine.Type
     ).to.equal('AWS::StepFunctions::StateMachine');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta1.Properties.DefinitionString
+      .MyStateMachine1StepFunctionsStateMachine.Properties.DefinitionString
     ).to.equal('"definition1"');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta2.Properties.DefinitionString
+      .MyStateMachine2StepFunctionsStateMachine.Properties.DefinitionString
     ).to.equal('"definition2"');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta1.Properties.RoleArn['Fn::GetAtt'][0]
+      .MyStateMachine1StepFunctionsStateMachine.Properties.RoleArn['Fn::GetAtt'][0]
     ).to.equal('IamRoleStateMachineExecution');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta2.Properties.RoleArn['Fn::GetAtt'][0]
+      .MyStateMachine2StepFunctionsStateMachine.Properties.RoleArn['Fn::GetAtt'][0]
     ).to.equal('IamRoleStateMachineExecution');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta1.DependsOn
+      .MyStateMachine1StepFunctionsStateMachine.DependsOn
     ).to.deep.eq(['IamRoleStateMachineExecution']);
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta2.DependsOn
+      .MyStateMachine2StepFunctionsStateMachine.DependsOn
     ).to.deep.eq(['IamRoleStateMachineExecution']);
   });
 
@@ -202,36 +202,36 @@ describe('#compileStateMachines', () => {
     serverlessStepFunctions.compileStateMachines();
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta1.Type
+      .MyStateMachine1StepFunctionsStateMachine.Type
     ).to.equal('AWS::StepFunctions::StateMachine');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta2.Type
+      .MyStateMachine2StepFunctionsStateMachine.Type
     ).to.equal('AWS::StepFunctions::StateMachine');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta1.Properties.DefinitionString
+      .MyStateMachine1StepFunctionsStateMachine.Properties.DefinitionString
     ).to.equal('"definition1"');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta2.Properties.DefinitionString
+      .MyStateMachine2StepFunctionsStateMachine.Properties.DefinitionString
     ).to.equal('"definition2"');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta1.Properties.RoleArn
+      .MyStateMachine1StepFunctionsStateMachine.Properties.RoleArn
     ).to.equal('arn:aws:role1');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta2.Properties.RoleArn
+      .MyStateMachine2StepFunctionsStateMachine.Properties.RoleArn
     ).to.equal('arn:aws:role2');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Outputs
-      .StateMachineBeta1Arn.Value.Ref
-    ).to.equal('StateMachineBeta1');
+      .MyStateMachine1StepFunctionsStateMachineArn.Value.Ref
+    ).to.equal('MyStateMachine1StepFunctionsStateMachine');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Outputs
-      .StateMachineBeta2Arn.Value.Ref
-    ).to.equal('StateMachineBeta2');
+      .MyStateMachine2StepFunctionsStateMachineArn.Value.Ref
+    ).to.equal('MyStateMachine2StepFunctionsStateMachine');
   });
 
   it('should respect CloudFormation intrinsic functions for role property', () => {
@@ -252,11 +252,11 @@ describe('#compileStateMachines', () => {
     serverlessStepFunctions.compileStateMachines();
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineWithIntrinsicRole1.Properties.RoleArn
+      .MyStateMachine1StepFunctionsStateMachine.Properties.RoleArn
     ).to.deep.equal({ 'Fn::Attr': ['RoleID', 'Arn'] });
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineWithIntrinsicRole2.Properties.RoleArn
+      .MyStateMachine2StepFunctionsStateMachine.Properties.RoleArn
     ).to.deep.equal({ Ref: 'CloudformationId' });
   });
 
@@ -300,19 +300,19 @@ describe('#compileStateMachines', () => {
     serverlessStepFunctions.compileStateMachines();
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta1.Type
+      .MyStateMachine1StepFunctionsStateMachine.Type
     ).to.equal('AWS::StepFunctions::StateMachine');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta2.Type
+      .MyStateMachine2StepFunctionsStateMachine.Type
     ).to.equal('AWS::StepFunctions::StateMachine');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta1.Properties.DefinitionString
+      .MyStateMachine1StepFunctionsStateMachine.Properties.DefinitionString
     ).to.equal('"definition1"');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta2.Properties.DefinitionString
+      .MyStateMachine2StepFunctionsStateMachine.Properties.DefinitionString
     ).to.equal('"definition2"');
   });
 
@@ -399,7 +399,7 @@ describe('#compileStateMachines', () => {
       .provider
       .compiledCloudFormationTemplate
       .Resources
-      .StateMachineBeta1
+      .MyStateMachine1StepFunctionsStateMachine
       .Properties
       .DefinitionString;
 
@@ -428,35 +428,35 @@ describe('#compileStateMachines', () => {
     serverlessStepFunctions.compileStateMachines();
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta1.Type
+      .MyStateMachine1StepFunctionsStateMachine.Type
     ).to.equal('AWS::StepFunctions::StateMachine');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta2.Type
+      .MyStateMachine2StepFunctionsStateMachine.Type
     ).to.equal('AWS::StepFunctions::StateMachine');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta1.Properties.DefinitionString
+      .MyStateMachine1StepFunctionsStateMachine.Properties.DefinitionString
     ).to.equal('"definition1"');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta2.Properties.DefinitionString
+      .MyStateMachine2StepFunctionsStateMachine.Properties.DefinitionString
     ).to.equal('"definition2"');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta1.Properties.RoleArn['Fn::GetAtt'][0]
+      .MyStateMachine1StepFunctionsStateMachine.Properties.RoleArn['Fn::GetAtt'][0]
     ).to.equal('IamRoleStateMachineExecution');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta2.Properties.RoleArn['Fn::GetAtt'][0]
+      .MyStateMachine2StepFunctionsStateMachine.Properties.RoleArn['Fn::GetAtt'][0]
     ).to.equal('IamRoleStateMachineExecution');
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta1.DependsOn
+      .MyStateMachine1StepFunctionsStateMachine.DependsOn
     ).to.deep.eq(['IamRoleStateMachineExecution', 'DynamoDBTable']);
     expect(serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources
-      .StateMachineBeta2.DependsOn
+      .MyStateMachine2StepFunctionsStateMachine.DependsOn
     ).to.deep.eq(['IamRoleStateMachineExecution', 'DynamoDBTable', 'KinesisStream']);
   });
 

--- a/lib/invoke/invoke.test.js
+++ b/lib/invoke/invoke.test.js
@@ -79,7 +79,7 @@ describe('invoke', () => {
             {
               Outputs: [
                 {
-                  OutputKey: 'StatemachinenameArn',
+                  OutputKey: 'MyStateMachineStepFunctionsStateMachineArn',
                   OutputValue: 'arn:aws:states:us-east-1:xxxx',
                   Description: 'Current StateMachine Arn' },
               ],

--- a/lib/naming.js
+++ b/lib/naming.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   getStateMachineLogicalId(stateMachineName, stateMachine) {
-    const custom = stateMachine ? stateMachine.id || stateMachine.name : null;
+    const custom = stateMachine ? stateMachine.id : null;
 
     if (custom) {
       return `${this.provider.naming.getNormalizedFunctionName(custom)}`;
@@ -13,7 +13,7 @@ module.exports = {
   },
 
   getStateMachineOutputLogicalId(stateMachineName, stateMachine) {
-    const custom = stateMachine ? stateMachine.id || stateMachine.name : null;
+    const custom = stateMachine ? stateMachine.id : null;
 
     if (custom) {
       return `${this.provider.naming.getNormalizedFunctionName(custom)}Arn`;

--- a/lib/naming.test.js
+++ b/lib/naming.test.js
@@ -36,7 +36,7 @@ describe('#naming', () => {
     it('should normalize the stateMachine name and add the standard suffix', () => {
       expect(serverlessStepFunctions.getStateMachineLogicalId('stateMachine',
         { name: 'alphaNumeric' }))
-      .to.equal('AlphaNumeric');
+      .to.equal('StateMachineStepFunctionsStateMachine');
     });
   });
 
@@ -44,7 +44,7 @@ describe('#naming', () => {
     it('should normalize the stateMachine output name and add the standard suffix', () => {
       expect(serverlessStepFunctions.getStateMachineOutputLogicalId('stateMachine',
         { name: 'alphaNumeric' }))
-      .to.equal('AlphaNumericArn');
+      .to.equal('StateMachineStepFunctionsStateMachineArn');
     });
   });
 


### PR DESCRIPTION
This changes the cloudformation resource key names that are chosen when a custom `name` for the step function is defined.

Without this change, it is not possible to have a custom name for a step function while still being able to internally reference resources by a predictable key name. I think it is also consistent with the way that serverless works in general. For example, if a lambda function is given a name then it does not affect the cloudformation key name used.

```YAML
functions:
  myLambdaFunction:
    name: ${self:provider.environment.STACK_PREFIX}-${self:provider.environment.STAGE}-myLambdaFunction
    handler: handler.myLambda
```

Will yield a cloudformation key name of `MyLambdaFunctionLambdaFunction`.

It would seem to me that it is extremely important to remain consistent (and non-parameterised) within the serverless config and cloudformation template generation with respect to key names because of the extremely frequency with which it is necessary to use the `resources` block escape hatch.

#### Unit Tests
I have fixed the unit tests as they current exist, but if this is merged, then I think it is likely that several should be removed as they basically test nothing more than the non-custom name case now.

Resolves #142