### PR TITLE
Serverless warning fix

### DIFF
--- a/lib/yamlParser.js
+++ b/lib/yamlParser.js
@@ -13,35 +13,41 @@ module.exports = {
     const serverlessYmlPath = path.join(servicePath, 'serverless.yml');
     return this.serverless.yamlParser
       .parse(serverlessYmlPath)
-      .then(serverlessFileParam =>
-        this.serverless.variables.populateObject(serverlessFileParam)
-        .then(parsedObject => {
-          this.serverless.service.stepFunctions = {};
-          this.serverless.service.stepFunctions.stateMachines
-              = parsedObject.stepFunctions
-            && parsedObject.stepFunctions.stateMachines
-              ? parsedObject.stepFunctions.stateMachines : {};
-          this.serverless.service.stepFunctions.activities
-              = parsedObject.stepFunctions
-            && parsedObject.stepFunctions.activities
-              ? parsedObject.stepFunctions.activities : [];
+      .then(serverlessFileParam => {
+        // load only what is needed for the plugin
+        if (serverlessFileParam.stepFunctions) {
+          return this.serverless.variables.populateObject(serverlessFileParam.stepFunctions)
+        }
 
-          if (!this.serverless.pluginManager.cliOptions.stage) {
-            this.serverless.pluginManager.cliOptions.stage = this.options.stage
-            || (this.serverless.service.provider && this.serverless.service.provider.stage)
-            || 'dev';
-          }
+        // backwards compatitbility
+        return this.serverless.variables.populateObject(serverlessFileParam)
+      })
+      .then(parsedObject => {
+        this.serverless.service.stepFunctions = {};
+        this.serverless.service.stepFunctions.stateMachines
+            = parsedObject.stepFunctions
+          && parsedObject.stepFunctions.stateMachines
+            ? parsedObject.stepFunctions.stateMachines : {};
+        this.serverless.service.stepFunctions.activities
+            = parsedObject.stepFunctions
+          && parsedObject.stepFunctions.activities
+            ? parsedObject.stepFunctions.activities : [];
 
-          if (!this.serverless.pluginManager.cliOptions.region) {
-            this.serverless.pluginManager.cliOptions.region = this.options.region
-            || (this.serverless.service.provider && this.serverless.service.provider.region)
-            || 'us-east-1';
-          }
+        if (!this.serverless.pluginManager.cliOptions.stage) {
+          this.serverless.pluginManager.cliOptions.stage = this.options.stage
+          || (this.serverless.service.provider && this.serverless.service.provider.stage)
+          || 'dev';
+        }
 
-          this.serverless.variables.populateService(this.serverless.pluginManager.cliOptions);
-          return BbPromise.resolve();
-        })
-      );
+        if (!this.serverless.pluginManager.cliOptions.region) {
+          this.serverless.pluginManager.cliOptions.region = this.options.region
+          || (this.serverless.service.provider && this.serverless.service.provider.region)
+          || 'us-east-1';
+        }
+
+        this.serverless.variables.populateService(this.serverless.pluginManager.cliOptions);
+        return BbPromise.resolve();
+      });
   },
 
   getAllStateMachines() {

--- a/lib/yamlParser.js
+++ b/lib/yamlParser.js
@@ -19,8 +19,8 @@ module.exports = {
           return this.serverless.variables.populateObject(serverlessFileParam.stepFunctions);
         }
 
-        // backwards compatitbility
-        return this.serverless.variables.populateObject(serverlessFileParam);
+        // return empty object if no stepFunctions param is given
+        return {};
       })
       .then(parsedObject => {
         this.serverless.service.stepFunctions = {};

--- a/lib/yamlParser.js
+++ b/lib/yamlParser.js
@@ -16,11 +16,11 @@ module.exports = {
       .then(serverlessFileParam => {
         // load only what is needed for the plugin
         if (serverlessFileParam.stepFunctions) {
-          return this.serverless.variables.populateObject(serverlessFileParam.stepFunctions)
+          return this.serverless.variables.populateObject(serverlessFileParam.stepFunctions);
         }
 
         // backwards compatitbility
-        return this.serverless.variables.populateObject(serverlessFileParam)
+        return this.serverless.variables.populateObject(serverlessFileParam);
       })
       .then(parsedObject => {
         this.serverless.service.stepFunctions = {};

--- a/lib/yamlParser.js
+++ b/lib/yamlParser.js
@@ -33,16 +33,16 @@ module.exports = {
           && parsedObject.stepFunctions.activities
             ? parsedObject.stepFunctions.activities : [];
 
-        if (!this.serverless.pluginManager.cliOptions.stage) {
-          this.serverless.pluginManager.cliOptions.stage = this.options.stage
-          || (this.serverless.service.provider && this.serverless.service.provider.stage)
-          || 'dev';
-        }
-
         if (!this.serverless.pluginManager.cliOptions.region) {
           this.serverless.pluginManager.cliOptions.region = this.options.region
           || (this.serverless.service.provider && this.serverless.service.provider.region)
           || 'us-east-1';
+        }
+
+        if (!this.serverless.pluginManager.cliOptions.stage) {
+          this.serverless.pluginManager.cliOptions.stage = this.options.stage
+          || (this.serverless.service.provider && this.serverless.service.provider.stage)
+          || 'dev';
         }
 
         this.serverless.variables.populateService(this.serverless.pluginManager.cliOptions);

--- a/lib/yamlParser.test.js
+++ b/lib/yamlParser.test.js
@@ -113,6 +113,20 @@ describe('#yamlParse', () => {
       });
     });
 
+    it('should create empty object when parse returns an empty object', () => {
+      serverlessStepFunctions.serverless.yamlParser.parse.restore();
+      serverlessStepFunctions.serverless.variables.populateObject.restore();
+      yamlParserStub = sinon.stub(serverlessStepFunctions.serverless.yamlParser, 'parse')
+      .returns(BbPromise.resolve({ noStepFunctionConfig: true }));
+      serverlessStepFunctions.yamlParse()
+      .then(() => {
+        expect(yamlParserStub.calledOnce).to.be.equal(true);
+        expect(populateServiceStub.calledOnce).to.be.equal(true);
+        expect(serverless.service.stepFunctions.stateMachines).to.be.deep.equal({});
+        expect(serverless.service.stepFunctions.activities).to.be.deep.equal([]);
+      });
+    });
+
     it('should create empty object when stepfunctions param are not given', () => {
       serverlessStepFunctions.serverless.yamlParser.parse.restore();
       serverlessStepFunctions.serverless.variables.populateObject.restore();

--- a/lib/yamlParser.test.js
+++ b/lib/yamlParser.test.js
@@ -118,10 +118,15 @@ describe('#yamlParse', () => {
       serverlessStepFunctions.serverless.variables.populateObject.restore();
       yamlParserStub = sinon.stub(serverlessStepFunctions.serverless.yamlParser, 'parse')
       .returns(BbPromise.resolve({ noStepFunctionConfig: true }));
+      yamlObjectParserStub = sinon.stub(serverless.variables,
+        'populateObject').returns(BbPromise.resolve({
+          stepFunctions: {},
+        }));
       serverlessStepFunctions.yamlParse()
       .then(() => {
         expect(yamlParserStub.calledOnce).to.be.equal(true);
         expect(populateServiceStub.calledOnce).to.be.equal(true);
+        expect(yamlObjectParserStub.calledOnce).to.be.equal(false);
         expect(serverless.service.stepFunctions.stateMachines).to.be.deep.equal({});
         expect(serverless.service.stepFunctions.activities).to.be.deep.equal([]);
       });


### PR DESCRIPTION
… available

We were getting a bunch of these warnings due to this plugin:

```
Serverless Warning --------------------------------------
 
  A valid service attribute to satisfy the declaration 'self:provider.environment.<var_name>' could not be found.
```

I found the stepFunctions config could be loaded directly in this manner, allowing other variables to not be loaded again.