### PR TITLE
fix: partition parsing of apigateway arn for events in govcloud region

### DIFF
--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -166,7 +166,11 @@ module.exports = {
         'Fn::Join': [
           '',
           [
-            'arn:aws:apigateway:',
+            'arn:',
+            {
+              Ref: 'AWS::Partition',
+            },
+            ':apigateway:',
             {
               Ref: 'AWS::Region',
             },

--- a/lib/deploy/events/apiGateway/methods.test.js
+++ b/lib/deploy/events/apiGateway/methods.test.js
@@ -138,7 +138,7 @@ describe('#methods()', () => {
 
         expect(serverlessStepFunctions.getMethodIntegration('stateMachine', 'custom', {
           action: 'DescribeExecution',
-        }).Properties.Integration.Uri['Fn::Join'][1][2])
+        }).Properties.Integration.Uri['Fn::Join'][1][4])
           .to.equal(':states:action/DescribeExecution');
       });
 


### PR DESCRIPTION
This PR fixes bug #307.  I have tested in a live AWS environment that this solves the bug, and I have ran/updated tests.

@theburningmonk @horike37 Please let me know if this is suitable for merging into master.  

Thanks.  