### PR TITLE
Add custom role to cloudwatch event which trigger step functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This is the Serverless Framework plugin for AWS Step Functions.
          - [Specify Input or Inputpath](#specify-input-or-inputpath)
          - [Specifying a Description](#specifying-a-description)
          - [Specifying a Name](#specifying-a-name)
+         - [Specifying a RoleArn](#specifying-a-rolearn)
          - [Specifying a custom CloudWatch EventBus](#specifying-a-custom-cloudwatch-eventbus)
  - [Tags](#tags)
  - [Commands](#commands)
@@ -989,6 +990,33 @@ stepFunctions:
       events:
         - cloudwatchEvent:
             name: 'my-cloudwatch-event-name'
+            event:
+              source:
+                - "aws.ec2"
+              detail-type:
+                - "EC2 Instance State-change Notification"
+              detail:
+                state:
+                  - pending
+      definition:
+        ...
+```
+
+#### Specifying a RoleArn
+
+You can also specify a CloudWatch Event RoleArn.
+The Amazon Resource Name (ARN) of the role that is used for target invocation.
+
+Required: No
+
+```yml
+stepFunctions:
+  stateMachines:
+    cloudwatchEvent:
+      events:
+        - cloudwatchEvent:
+            name: 'my-cloudwatch-event-name'
+            iamRole: 'arn:aws:iam::012345678910:role/Events-InvokeStepFunctions-Role'
             event:
               source:
                 - "aws.ec2"

--- a/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.js
+++ b/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.js
@@ -75,7 +75,7 @@ module.exports = {
               .getStateMachineLogicalId(stateMachineName, stateMachineObj);
             const cloudWatchLogicalId = this
               .getCloudWatchEventLogicalId(stateMachineName, eventRuleNumberInFunction);
-            const cloudWatchIamRoleLogicalId = eventRule.iamRole || this
+            const cloudWatchIamRoleLogicalId = this
               .getCloudWatchEventToStepFunctionsIamRoleLogicalId(stateMachineName);
             const cloudWatchId = this.getCloudWatchEventId(stateMachineName);
             const policyName = this.getCloudWatchEventPolicyName(stateMachineName);

--- a/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.js
+++ b/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.js
@@ -94,7 +94,7 @@ module.exports = {
                     ${InputPath ? `"InputPath": "${InputPath.replace(/\r?\n/g, '')}",` : ''}
                     "Arn": { "Ref": "${stateMachineLogicalId}" },
                     "Id": "${cloudWatchId}",
-                    ${IamRole ? `"RoleArn":"${IamRole}"`:`"RoleArn": {
+                    ${IamRole ? `"RoleArn":"${IamRole}"` : `"RoleArn": {
                       "Fn::GetAtt": [
                         "${cloudWatchIamRoleLogicalId}",
                         "Arn"
@@ -148,17 +148,18 @@ module.exports = {
               [cloudWatchLogicalId]: JSON.parse(cloudWatchEventRuleTemplate),
             };
 
-            const objectsToMerge = [newCloudWatchEventRuleObject]
+            const objectsToMerge = [newCloudWatchEventRuleObject];
 
-            if(!IamRole){
+            if (!IamRole) {
               const newPermissionObject = {
                 [cloudWatchIamRoleLogicalId]: JSON.parse(iamRoleTemplate),
               };
-              
-              objectsToMerge.push(newPermissionObject)
+
+              objectsToMerge.push(newPermissionObject);
             }
 
-            _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, ...objectsToMerge);
+            _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+              ...objectsToMerge);
           }
         });
       }

--- a/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.js
+++ b/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.js
@@ -22,6 +22,7 @@ module.exports = {
             let Description;
             let Name;
             let EventBusName;
+            let IamRole;
 
             if (typeof eventRule === 'object') {
               if (!eventRule.event) {
@@ -43,6 +44,7 @@ module.exports = {
               Description = eventRule.description;
               Name = eventRule.name;
               EventBusName = eventRule.eventBusName;
+              IamRole = eventRule.iamRole;
 
               if (Input && InputPath) {
                 const errorMessage = [
@@ -92,12 +94,12 @@ module.exports = {
                     ${InputPath ? `"InputPath": "${InputPath.replace(/\r?\n/g, '')}",` : ''}
                     "Arn": { "Ref": "${stateMachineLogicalId}" },
                     "Id": "${cloudWatchId}",
-                    "RoleArn": {
+                    ${IamRole ? `"RoleArn":"${IamRole}"`:`"RoleArn": {
                       "Fn::GetAtt": [
                         "${cloudWatchIamRoleLogicalId}",
                         "Arn"
                       ]
-                    }
+                    }`}
                   }]
                 }
               }
@@ -146,12 +148,17 @@ module.exports = {
               [cloudWatchLogicalId]: JSON.parse(cloudWatchEventRuleTemplate),
             };
 
-            const newPermissionObject = {
-              [cloudWatchIamRoleLogicalId]: JSON.parse(iamRoleTemplate),
-            };
+            const objectsToMerge = [newCloudWatchEventRuleObject]
 
-            _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-              newCloudWatchEventRuleObject, newPermissionObject);
+            if(!IamRole){
+              const newPermissionObject = {
+                [cloudWatchIamRoleLogicalId]: JSON.parse(iamRoleTemplate),
+              };
+              
+              objectsToMerge.push(newPermissionObject)
+            }
+
+            _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, ...objectsToMerge);
           }
         });
       }

--- a/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.js
+++ b/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.js
@@ -73,7 +73,7 @@ module.exports = {
               .getStateMachineLogicalId(stateMachineName, stateMachineObj);
             const cloudWatchLogicalId = this
               .getCloudWatchEventLogicalId(stateMachineName, eventRuleNumberInFunction);
-            const cloudWatchIamRoleLogicalId = this
+            const cloudWatchIamRoleLogicalId = eventRule.iamRole || this
               .getCloudWatchEventToStepFunctionsIamRoleLogicalId(stateMachineName);
             const cloudWatchId = this.getCloudWatchEventId(stateMachineName);
             const policyName = this.getCloudWatchEventPolicyName(stateMachineName);


### PR DESCRIPTION
Possible fix for this issue https://github.com/serverless-operations/serverless-step-functions/issues/306 It allows to add already created role to CloudWatch event