### PR TITLE
fix(README): should specify the role's ARN

### DIFF
--- a/README.md
+++ b/README.md
@@ -1088,7 +1088,7 @@ stepFunctions:
   stateMachines:
     hello:
       role:
-        Ref: StateMachineRole
+        Fn::GetAtt: ["StateMachineRole", "Arn"]
       definition:
         ...
 


### PR DESCRIPTION
This is a pull request which fixes README only.

#156 added support for CloudFormation intrinsic function for role, such as `Ref` or `Fn::GetAtt`. The function should return the role's ARN, not its name.

The example in README `Ref: StateMachineRole` doesn't work because that returns the role's name. Instead, we should use `Fn::GetAtt`.