### PR TITLE
Allow logging to standard workflow

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -384,7 +384,7 @@ module.exports = {
       const taskStates = getTaskStates(stateMachineObj.definition.States);
       let iamPermissions = getIamPermissions.bind(this)(taskStates);
 
-      if (stateMachineObj.type === 'EXPRESS') {
+      if (stateMachineObj.loggingConfig) {
         iamPermissions.push({
           action: 'logs:CreateLogDelivery,logs:GetLogDelivery,logs:UpdateLogDelivery,logs:DeleteLogDelivery,logs:ListLogDeliveries,logs:PutResourcePolicy,logs:DescribeResourcePolicies,logs:DescribeLogGroups',
           resource: '*',

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -1786,12 +1786,11 @@ describe('#compileIamRole', () => {
     expect(lambdaPermissions[0].Resource).to.deep.equal(lambdaArns);
   });
 
-  it('should give CloudWatch Logs permissions for Express Workflow', () => {
+  it('should give CloudWatch Logs permissions', () => {
     serverless.service.stepFunctions = {
       stateMachines: {
         myStateMachine1: {
           id: 'StateMachine1',
-          type: 'EXPRESS',
           loggingConfig: {
             destinations: [
               {

--- a/lib/deploy/stepFunctions/compileStateMachines.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.js
@@ -188,7 +188,7 @@ module.exports = {
           _.forEach(stateMachineTags, tag => Tags.push(tag));
         }
 
-        if (value.type === 'EXPRESS' && value.loggingConfig) {
+        if (value.loggingConfig) {
           const Destinations = (value.loggingConfig.destinations || [])
             .map(arn => ({
               CloudWatchLogsLogGroup: {

--- a/lib/deploy/stepFunctions/compileStateMachines.test.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.test.js
@@ -1307,12 +1307,44 @@ describe('#compileStateMachines', () => {
     expect(definitionString).to.not.contain('#{AWS::AccountId}');
   });
 
-  it('should compile logging configuration for Express Workflows', () => {
+  it('should compile Express Workflow', () => {
     serverless.service.stepFunctions = {
       stateMachines: {
         myStateMachine1: {
           name: 'stateMachineBeta1',
           type: 'EXPRESS',
+          definition: {
+            StartAt: 'A',
+            States: {
+              A: {
+                Type: 'Task',
+                Resource: 'arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:hello',
+                End: true,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    serverlessStepFunctions.compileStateMachines();
+    const actual = serverlessStepFunctions
+      .serverless
+      .service
+      .provider
+      .compiledCloudFormationTemplate
+      .Resources
+      .StateMachineBeta1
+      .Properties;
+
+    expect(actual.StateMachineType).to.equal('EXPRESS');
+  });
+
+  it('should compile logging configuration', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          name: 'stateMachineBeta1',
           loggingConfig: {
             destinations: [
               {
@@ -1344,7 +1376,6 @@ describe('#compileStateMachines', () => {
       .StateMachineBeta1
       .Properties;
 
-    expect(actual.StateMachineType).to.equal('EXPRESS');
     expect(actual).to.haveOwnProperty('LoggingConfiguration');
     expect(actual.LoggingConfiguration.Level).to.equal('OFF'); // default value
     expect(actual.LoggingConfiguration.IncludeExecutionData).to.equal(false); // default value


### PR DESCRIPTION
Currently, logging is available only for express workflows. this pull request enables it for standard workflows as well