### PR TITLE
feat: not output cloudformation outputs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ stepFunctions:
 
 ### Disable Output Cloudformation Outputs section
 
-Disables output in Outputs section.
+Disables output in the CloudFormation Outputs section.  if you define many state-machines in serverless.yml, there is a possibility of reaching out a CloudFormation limits in which the maximum number of outputs is 60. If you define `noOutput: true`, you can prevent automatically output by this plugin.
 
 ```yaml
 stepFUnctions:

--- a/README.md
+++ b/README.md
@@ -351,6 +351,15 @@ stepFunctions:
   validate: true
 ```
 
+### Disable Output Cloudformation Outputs section
+
+Disables output in Outputs section.
+
+```yaml
+stepFUnctions:
+  noOutput: true
+```
+
 ### Express Workflow
 
 At re:invent 2019, AWS [introduced Express Workflows](https://aws.amazon.com/about-aws/whats-new/2019/12/introducing-aws-step-functions-express-workflows/) as a cheaper, more scalable alternative (but with a cut-down set of features). See [this page](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-standard-vs-express.html) for differences between standard and express workflows.

--- a/lib/deploy/stepFunctions/compileStateMachines.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.js
@@ -243,8 +243,10 @@ module.exports = {
           [stateMachineOutputLogicalId]: stateMachineOutPutObject,
         };
 
-        _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs,
-          newStateMachineOutPutObject);
+        if (this.serverless.service.stepFunctions.noOutput !== true) {
+          _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs,
+            newStateMachineOutPutObject);
+        }
 
         return BbPromise.resolve();
       });

--- a/lib/deploy/stepFunctions/compileStateMachines.test.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.test.js
@@ -1391,6 +1391,26 @@ describe('#compileStateMachines', () => {
     });
   });
 
+  it('should output cloudformation outputs section', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          definition: 'definition1',
+          role: 'arn:aws:role1',
+        },
+        myStateMachine2: {
+          name: 'stateMachineBeta2',
+          definition: 'definition2',
+          role: 'arn:aws:role2',
+        },
+      },
+      noOutput: false,
+    };
+    serverlessStepFunctions.compileStateMachines();
+    expect(Object.keys(serverlessStepFunctions.serverless.service.provider
+      .compiledCloudFormationTemplate.Outputs).length).to.equal(2);
+  });
+
   it('should not output cloudformation outputs section', () => {
     serverless.service.stepFunctions = {
       stateMachines: {

--- a/lib/deploy/stepFunctions/compileStateMachines.test.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.test.js
@@ -1390,4 +1390,24 @@ describe('#compileStateMachines', () => {
       },
     });
   });
+
+  it('should not output cloudformation outputs section', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          definition: 'definition1',
+          role: 'arn:aws:role1',
+        },
+        myStateMachine2: {
+          name: 'stateMachineBeta2',
+          definition: 'definition2',
+          role: 'arn:aws:role2',
+        },
+      },
+      noOutput: true,
+    };
+    serverlessStepFunctions.compileStateMachines();
+    expect(Object.keys(serverlessStepFunctions.serverless.service.provider
+      .compiledCloudFormationTemplate.Outputs).length).to.equal(0);
+  });
 });

--- a/lib/yamlParser.js
+++ b/lib/yamlParser.js
@@ -27,6 +27,7 @@ module.exports = {
         .then((parsedObject) => {
           this.serverless.service.stepFunctions = {
             validate: parsedObject.stepFunctions ? parsedObject.stepFunctions.validate : false,
+            noOutput: parsedObject.stepFunctions ? parsedObject.stepFunctions.noOutput : false,
           };
           this.serverless.service.stepFunctions.stateMachines = parsedObject.stepFunctions
             && parsedObject.stepFunctions.stateMachines


### PR DESCRIPTION
This option suppresses output to the Outputs section of Cloudformation.

https://dev.classmethod.jp/articles/serverless-framework-stepfunctions-many-statemachine-workaround/