### PR TITLE
Trigger error when 'definition' is missing

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -381,6 +381,10 @@ module.exports = {
         return;
       }
 
+      if (!stateMachineObj.definition) {
+        throw new Error(`Missing "definition" for state machine ${stateMachineName}`);
+      }
+
       const taskStates = getTaskStates(stateMachineObj.definition.States);
       let iamPermissions = getIamPermissions.bind(this)(taskStates);
 


### PR DESCRIPTION
Hello 👋

Today I had a typo in my configuration, I wrote "definitions" instead of "definition"...
Serverless was telling me "TypeError: Cannot read property 'States' of undefined" after some time when deploying.
Without opening the code I couldn't understand what happend. Thus I added this error to help end user to debug faster :)