### PR TITLE
updates readme to fix multifile state machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1258,10 +1258,11 @@ serverless.yml:
 
 ```yml
 stepFunctions:
-  hellostepfunc1:
-    ${file(includes/state-machine-1.yml)}
-  hellostepfunc2:
-    ${file(includes/state-machine-2.yml)}
+  stateMachines:
+    hellostepfunc1:
+      ${file(includes/state-machine-1.yml)}
+    hellostepfunc2:
+      ${file(includes/state-machine-2.yml)}
 
 plugins:
   - serverless-step-functions


### PR DESCRIPTION
Noticed the example was missing the `stateMachines:` key when defining multiple file state machines. 

Thanks a lot for the plugin, it's really great!