### PR TITLE
Add IAM Role generation support for resource "startExecution.sync:2"

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -333,6 +333,7 @@ function getIamPermissions(taskStates) {
 
       case 'arn:aws:states:::states:startExecution':
       case 'arn:aws:states:::states:startExecution.sync':
+      case 'arn:aws:states:::states:startExecution.sync:2':
       case 'arn:aws:states:::states:startExecution.waitForTaskToken':
         return getStepFunctionsPermissions(state);
 

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -1583,6 +1583,15 @@ describe('#compileIamRole', () => {
           },
           C: {
             Type: 'Task',
+            Resource: 'arn:aws:states:::states:startExecution.sync:2',
+            Parameters: {
+              StateMachineArn: stateMachineArn,
+              Input: {},
+            },
+            Next: 'D',
+          },
+          D: {
+            Type: 'Task',
             Resource: 'arn:aws:states:::states:startExecution.waitForTaskToken',
             Parameters: {
               StateMachineArn: stateMachineArn,


### PR DESCRIPTION
Hi,

I added a support for IAM Role generation when using `arn:aws:states:::states:startExecution.sync:2`. As [AWS documentation](https://docs.aws.amazon.com/step-functions/latest/dg/connect-stepfunctions.html) describe
![state output specification](https://user-images.githubusercontent.com/8782994/81474227-341c0f00-9204-11ea-8ced-e880c086c0c0.png)

the `:2` version can be used to have JSON output of nested step function instead of encoded string.