### PR TITLE
feat(ts-support): adds ts support

### DIFF
--- a/lib/yamlParser.js
+++ b/lib/yamlParser.js
@@ -17,7 +17,7 @@ module.exports = {
     const serviceFileName = this.options.config || this.serverless.config.serverless.service.serviceFilename || 'serverless.yml';
     const serverlessYmlPath = path.join(servicePath, serviceFileName);
 
-    if (['.js', '.json'].includes(path.extname(serverlessYmlPath))) {
+    if (['.js', '.json', '.ts'].includes(path.extname(serverlessYmlPath))) {
       parse = this.loadFromRequiredFile;
     } else {
       parse = fromYamlFile;

--- a/lib/yamlParser.test.js
+++ b/lib/yamlParser.test.js
@@ -148,6 +148,23 @@ describe('#yamlParse', () => {
         });
     });
 
+    it('should be able to load from a ts file', () => {
+      serverless.config.serverless.service.serviceFilename = 'serverless.ts';
+      const requireFileStub = sinon.stub(serverlessStepFunctions, 'loadFromRequiredFile')
+        .returns(BbPromise.resolve({
+          stepFunctions: {
+            stateMachines: 'stepFunctions',
+            activities: 'my-activity',
+          },
+        }));
+      serverlessStepFunctions.yamlParse()
+        .then(() => {
+          expect(requireFileStub.calledOnce).to.be.equal(true);
+          expect(serverless.service.stepFunctions.stateMachines).to.be.equal('stepFunctions');
+          expect(serverless.service.stepFunctions.activities).to.be.equal('my-activity');
+        });
+    });
+
     it('should create empty object when stepfunctions param are not given', () => {
       serverlessStepFunctions.serverless.yamlParser.parse.restore();
       serverlessStepFunctions.serverless.variables.populateObject.restore();


### PR DESCRIPTION
addresses: https://github.com/serverless-operations/serverless-step-functions/issues/349

serverless now supports typescript: https://github.com/serverless/serverless/pull/7755

updating this plugin to look for `.ts` files