### PR TITLE
ci: updated .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 
 matrix:
   include:
-    - node_js: 8
     - node_js: 10
     - node_is: 12
     - node_js: 12


### PR DESCRIPTION
deprecate node8 tests since it's no longer supported on Lambda