### PR TITLE
Fix typo in example code in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ stepFunctions:
 Disables output in the CloudFormation Outputs section.  if you define many state-machines in serverless.yml, there is a possibility of reaching out a CloudFormation limits in which the maximum number of outputs is 60. If you define `noOutput: true`, you can prevent automatically output by this plugin.
 
 ```yaml
-stepFUnctions:
+stepFunctions:
   noOutput: true
 ```
 

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ stepFunctions:
 
 ### Disable Output Cloudformation Outputs section
 
-Disables output in the CloudFormation Outputs section.  if you define many state-machines in serverless.yml, there is a possibility of reaching out a CloudFormation limits in which the maximum number of outputs is 60. If you define `noOutput: true`, you can prevent automatically output by this plugin.
+Disables the generation of outputs in the CloudFormation Outputs section. If you define many state machines in serverless.yml you may reach the CloudFormation limit of 60 outputs. If you define `noOutput: true` then this plugin will not generate outputs automatically.
 
 ```yaml
 stepFunctions:


### PR DESCRIPTION
I also tried to tidy up some of the text a bit (the second commit).