### PR TITLE
feat: moved authorizers out into code

### DIFF
--- a/lib/deploy/events/apiGateway/authorizers.js
+++ b/lib/deploy/events/apiGateway/authorizers.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const BbPromise = require('bluebird');
+const _ = require('lodash');
+const awsArnRegExs = require('../../../utils/arnRegularExpressions');
+
+module.exports = {
+  compileAuthorizers() {
+    this.validated.events.forEach((event) => {
+      if (event.http.authorizer && event.http.authorizer.arn) {
+        const authorizer = event.http.authorizer;
+        const authorizerProperties = {
+          AuthorizerResultTtlInSeconds: authorizer.resultTtlInSeconds,
+          IdentitySource: authorizer.identitySource,
+          Name: authorizer.name,
+          RestApiId: this.provider.getApiGatewayRestApiId(),
+        };
+
+        if (typeof authorizer.identityValidationExpression === 'string') {
+          Object.assign(authorizerProperties, {
+            IdentityValidationExpression:
+              authorizer.identityValidationExpression,
+          });
+        }
+
+        const authorizerLogicalId = this.provider.naming.getAuthorizerLogicalId(
+          authorizer.name,
+        );
+
+        if (
+          (authorizer.type || '').toUpperCase() === 'COGNITO_USER_POOLS'
+          || (typeof authorizer.arn === 'string'
+            && awsArnRegExs.cognitoIdpArnExpr.test(authorizer.arn))
+        ) {
+          authorizerProperties.Type = 'COGNITO_USER_POOLS';
+          authorizerProperties.ProviderARNs = [authorizer.arn];
+        } else {
+          authorizerProperties.AuthorizerUri = {
+            'Fn::Join': [
+              '',
+              [
+                'arn:',
+                { Ref: 'AWS::Partition' },
+                ':apigateway:',
+                { Ref: 'AWS::Region' },
+                ':lambda:path/2015-03-31/functions/',
+                authorizer.arn,
+                '/invocations',
+              ],
+            ],
+          };
+          authorizerProperties.Type = authorizer.type
+            ? authorizer.type.toUpperCase()
+            : 'TOKEN';
+        }
+
+        _.merge(
+          this.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources,
+          {
+            [authorizerLogicalId]: {
+              Type: 'AWS::ApiGateway::Authorizer',
+              Properties: authorizerProperties,
+            },
+          },
+        );
+      }
+    });
+    return BbPromise.resolve();
+  },
+};

--- a/lib/deploy/events/apiGateway/authorizers.test.js
+++ b/lib/deploy/events/apiGateway/authorizers.test.js
@@ -1,0 +1,226 @@
+'use strict';
+
+const expect = require('chai').expect;
+const Serverless = require('serverless/lib/Serverless');
+const AwsProvider = require('serverless/lib/plugins/aws/provider/awsProvider');
+const ServerlessStepFunctions = require('./../../../index');
+
+describe('#compileAuthorizers()', () => {
+  let awsCompileApigEvents;
+
+  beforeEach(() => {
+    const options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
+    const serverless = new Serverless();
+    serverless.setProvider('aws', new AwsProvider(serverless));
+    serverless.service.service = 'first-service';
+    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
+    awsCompileApigEvents = new ServerlessStepFunctions(serverless, options);
+    awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
+    awsCompileApigEvents.validated = {};
+  });
+
+  it('should create an authorizer with minimal configuration', () => {
+    awsCompileApigEvents.validated.events = [
+      {
+        http: {
+          path: 'users/create',
+          method: 'POST',
+          authorizer: {
+            name: 'authorizer',
+            arn: { 'Fn::GetAtt': ['SomeLambdaFunction', 'Arn'] },
+            resultTtlInSeconds: 300,
+            identitySource: 'method.request.header.Authorization',
+          },
+        },
+      },
+    ];
+
+    return awsCompileApigEvents.compileAuthorizers().then(() => {
+      const resource = awsCompileApigEvents.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources.AuthorizerApiGatewayAuthorizer;
+
+      expect(resource.Type).to.equal('AWS::ApiGateway::Authorizer');
+      expect(resource.Properties.AuthorizerResultTtlInSeconds).to.equal(300);
+      expect(resource.Properties.AuthorizerUri).to.deep.equal({
+        'Fn::Join': [
+          '',
+          [
+            'arn:',
+            { Ref: 'AWS::Partition' },
+            ':apigateway:',
+            { Ref: 'AWS::Region' },
+            ':lambda:path/2015-03-31/functions/',
+            { 'Fn::GetAtt': ['SomeLambdaFunction', 'Arn'] },
+            '/invocations',
+          ],
+        ],
+      });
+      expect(resource.Properties.IdentitySource).to.equal('method.request.header.Authorization');
+      expect(resource.Properties.IdentityValidationExpression).to.equal(undefined);
+      expect(resource.Properties.Name).to.equal('authorizer');
+      expect(resource.Properties.RestApiId.Ref).to.equal('ApiGatewayRestApi');
+      expect(resource.Properties.Type).to.equal('TOKEN');
+    });
+  });
+
+  it('should create an authorizer with provided configuration', () => {
+    awsCompileApigEvents.validated.events = [
+      {
+        http: {
+          path: 'users/create',
+          method: 'POST',
+          authorizer: {
+            name: 'authorizer',
+            arn: 'foo',
+            resultTtlInSeconds: 500,
+            identitySource: 'method.request.header.Custom',
+            identityValidationExpression: 'regex',
+          },
+        },
+      },
+    ];
+
+    return awsCompileApigEvents.compileAuthorizers().then(() => {
+      const resource = awsCompileApigEvents.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources.AuthorizerApiGatewayAuthorizer;
+
+      expect(resource.Type).to.equal('AWS::ApiGateway::Authorizer');
+      expect(resource.Properties.AuthorizerUri).to.deep.equal({
+        'Fn::Join': [
+          '',
+          [
+            'arn:',
+            { Ref: 'AWS::Partition' },
+            ':apigateway:',
+            { Ref: 'AWS::Region' },
+            ':lambda:path/2015-03-31/functions/',
+            'foo',
+            '/invocations',
+          ],
+        ],
+      });
+      expect(resource.Properties.AuthorizerResultTtlInSeconds).to.equal(500);
+      expect(resource.Properties.IdentitySource).to.equal('method.request.header.Custom');
+      expect(resource.Properties.IdentityValidationExpression).to.equal('regex');
+      expect(resource.Properties.Name).to.equal('authorizer');
+      expect(resource.Properties.RestApiId.Ref).to.equal('ApiGatewayRestApi');
+      expect(resource.Properties.Type).to.equal('TOKEN');
+    });
+  });
+
+  it('should apply optional provided type value to Authorizer Type', () => {
+    awsCompileApigEvents.validated.events = [
+      {
+        http: {
+          path: 'users/create',
+          method: 'POST',
+          authorizer: {
+            name: 'authorizer',
+            arn: 'foo',
+            resultTtlInSeconds: 500,
+            identityValidationExpression: 'regex',
+            type: 'request',
+          },
+        },
+      },
+    ];
+
+    return awsCompileApigEvents.compileAuthorizers().then(() => {
+      const resource = awsCompileApigEvents.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources.AuthorizerApiGatewayAuthorizer;
+
+      expect(resource.Type).to.equal('AWS::ApiGateway::Authorizer');
+      expect(resource.Properties.Type).to.equal('REQUEST');
+    });
+  });
+
+  it('should apply TOKEN as authorizer Type when not given a type value', () => {
+    awsCompileApigEvents.validated.events = [
+      {
+        http: {
+          path: 'users/create',
+          method: 'POST',
+          authorizer: {
+            name: 'authorizer',
+            arn: 'foo',
+            resultTtlInSeconds: 500,
+            identityValidationExpression: 'regex',
+          },
+        },
+      },
+    ];
+
+    return awsCompileApigEvents.compileAuthorizers().then(() => {
+      const resource = awsCompileApigEvents.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources
+        .AuthorizerApiGatewayAuthorizer;
+
+      expect(resource.Type).to.equal('AWS::ApiGateway::Authorizer');
+      expect(resource.Properties.Type).to.equal('TOKEN');
+    });
+  });
+
+  it('should create a valid cognito user pool authorizer', () => {
+    awsCompileApigEvents.validated.events = [
+      {
+        http: {
+          path: 'users/create',
+          method: 'POST',
+          authorizer: {
+            name: 'authorizer',
+            arn: 'arn:aws:cognito-idp:us-east-1:xxx:userpool/us-east-1_ZZZ',
+          },
+        },
+      },
+    ];
+
+    return awsCompileApigEvents.compileAuthorizers().then(() => {
+      const resource = awsCompileApigEvents.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources
+        .AuthorizerApiGatewayAuthorizer;
+
+      expect(resource.Properties.Name).to.equal('authorizer');
+
+      expect(resource.Properties.ProviderARNs[0]).to.equal(
+        'arn:aws:cognito-idp:us-east-1:xxx:userpool/us-east-1_ZZZ',
+      );
+
+      expect(resource.Properties.Type).to.equal('COGNITO_USER_POOLS');
+    });
+  });
+
+  it('should create a valid cognito user pool authorizer using Fn::GetAtt', () => {
+    awsCompileApigEvents.validated.events = [
+      {
+        http: {
+          path: 'users/create',
+          method: 'POST',
+          authorizer: {
+            name: 'authorizer',
+            type: 'COGNITO_USER_POOLS',
+            arn: {
+              'Fn::GetAtt': ['CognitoUserPool', 'Arn'],
+            },
+          },
+        },
+      },
+    ];
+
+    return awsCompileApigEvents.compileAuthorizers().then(() => {
+      const resource = awsCompileApigEvents.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources
+        .AuthorizerApiGatewayAuthorizer;
+
+      expect(resource.Properties.Name).to.equal('authorizer');
+
+      expect(resource.Properties.ProviderARNs[0]).to.deep.equal({
+        'Fn::GetAtt': ['CognitoUserPool', 'Arn'],
+      });
+
+      expect(resource.Properties.Type).to.equal('COGNITO_USER_POOLS');
+    });
+  });
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const BbPromise = require('bluebird');
-const httpAuthorizers = require('serverless/lib/plugins/aws/package/compile/events/apiGateway/lib/authorizers');
 const _ = require('lodash');
 const chalk = require('chalk');
+const httpAuthorizers = require('./deploy/events/apiGateway/authorizers');
 const compileStateMachines = require('./deploy/stepFunctions/compileStateMachines');
 const compileActivities = require('./deploy/stepFunctions/compileActivities');
 const compileIamRole = require('./deploy/stepFunctions/compileIamRole');

--- a/package.json
+++ b/package.json
@@ -40,15 +40,15 @@
     "mocha-param": "^2.0.0",
     "nyc": "^15.0.0",
     "semantic-release": "^15.14.0",
-    "sinon": "^1.17.5"
+    "sinon": "^1.17.5",
+    "serverless": "^1.72.0"
   },
   "dependencies": {
     "@hapi/joi": "^15.0.2",
     "asl-validator": "^1.7.0",
     "bluebird": "^3.4.0",
     "chalk": "^1.1.1",
-    "lodash": "^4.17.11",
-    "serverless": "^1.72.0"
+    "lodash": "^4.17.11"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Removed the Dependency on the serverless library resolving issue #368 

It's pretty much copied from the library which seems wrong, but the rest of the deploy/events/apiGateway code are pretty much the same. 