### PR TITLE
fix: added iam permission for x-ray

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -429,6 +429,13 @@ module.exports = {
         });
       }
 
+      if (stateMachineObj.tracingConfig) {
+        iamPermissions.push({
+          action: 'xray:PutTraceSegments,xray:PutTelemetryRecords,xray:GetSamplingRules,xray:GetSamplingTargets',
+          resource: '*',
+        });
+      }
+
       iamPermissions = consolidatePermissionsByAction(iamPermissions);
       iamPermissions = consolidatePermissionsByResource(iamPermissions);
       const iamStatements = getIamStatements(iamPermissions);

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -1902,6 +1902,44 @@ describe('#compileIamRole', () => {
     ]);
   });
 
+  it('should give X-Ray permissions', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          id: 'StateMachine1',
+          tracingConfig: {
+            enabled: true,
+          },
+          definition: {
+            StartAt: 'A',
+            States: {
+              A: {
+                Type: 'Task',
+                Resource: 'arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:hello',
+                End: true,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    serverlessStepFunctions.compileIamRole();
+    const statements = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources.StateMachine1Role
+      .Properties.Policies[0].PolicyDocument.Statement;
+
+    const tracingPermissions = statements.filter(s => s.Action.includes('xray:PutTraceSegments'));
+    expect(tracingPermissions).to.have.lengthOf(1);
+    expect(tracingPermissions[0].Resource).to.equal('*');
+    expect(tracingPermissions[0].Action).to.deep.equal([
+      'xray:PutTraceSegments',
+      'xray:PutTelemetryRecords',
+      'xray:GetSamplingRules',
+      'xray:GetSamplingTargets',
+    ]);
+  });
+
   it('should support variable FunctionName', () => {
     serverless.service.stepFunctions = {
       stateMachines: {


### PR DESCRIPTION
#373 

It generates IAM permission for StateMachine to use X-Ray when enabled tracingConfig.

(Should I rename commit type 'feat' to 'fix'?)