### PR TITLE
feat: added Fn::Join to ARN deployment schemas

### DIFF
--- a/lib/deploy/stepFunctions/compileAlarms.schema.js
+++ b/lib/deploy/stepFunctions/compileAlarms.schema.js
@@ -14,6 +14,17 @@ const arn = Joi.alternatives().try(
       Joi.object(),
     ),
   }),
+  Joi.object().keys({
+    'Fn::Join': Joi.array().items([
+      Joi.string(),
+      Joi.array().items([
+        Joi.string(),
+        Joi.object().keys({
+          Ref: Joi.string(),
+        }),
+      ]),
+    ]),
+  }),
 );
 
 const topics = Joi.object().keys({

--- a/lib/deploy/stepFunctions/compileNotifications.schema.js
+++ b/lib/deploy/stepFunctions/compileNotifications.schema.js
@@ -8,6 +8,17 @@ const arn = Joi.alternatives().try(
   Joi.object().keys({
     'Fn::GetAtt': Joi.array().items(Joi.string()),
   }),
+  Joi.object().keys({
+    'Fn::Join': Joi.array().items([
+      Joi.string(),
+      Joi.array().items([
+        Joi.string(),
+        Joi.object().keys({
+          Ref: Joi.string(),
+        }),
+      ]),
+    ]),
+  }),
 );
 
 const sqsWithParams = Joi.object().keys({

--- a/lib/deploy/stepFunctions/compileStateMachines.schema.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.schema.js
@@ -14,6 +14,17 @@ const arn = Joi.alternatives().try(
       Joi.object(),
     ),
   }),
+  Joi.object().keys({
+    'Fn::Join': Joi.array().items([
+      Joi.string(),
+      Joi.array().items([
+        Joi.string(),
+        Joi.object().keys({
+          Ref: Joi.string(),
+        }),
+      ]),
+    ]),
+  }),
 );
 
 const definition = Joi.alternatives().try(


### PR DESCRIPTION
Hi there!

I found myself wanting to be able to use the `Fn::Join` CloudFormation pseudo parameter function and noticed that it was being rejected by validation. After adding it to the ARN deploy schemas, it seems to work fine - resources are created as expected.

I have only tested alarms and notifications, however I added it to the state machines schema as well for consistency.

What do you think about allowing `Fn::Join` to the validation schemas? I'm more than happy to make any changes you'd like to the code.

Cheers, and thank you for the useful plugin!