### PR TITLE
Stringify Event Bus Name To Allow Intrinsic Funcitons

### DIFF
--- a/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.js
+++ b/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.js
@@ -43,7 +43,7 @@ module.exports = {
               InputPath = eventRule.inputPath;
               Description = eventRule.description;
               Name = eventRule.name;
-              EventBusName = eventRule.eventBusName;
+              EventBusName = JSON.stringify(eventRule.eventBusName);
               IamRole = eventRule.iamRole;
 
               if (Input && InputPath) {


### PR DESCRIPTION
We should be able to pass AWS intrinsic functions in as eventBusName.

`
eventBusName:
  Fn::If:
    - isLocal
    - Fn::GetAtt: [localEventBus, Name]
    - ${self:custom.eventBusName}
`