### PR TITLE
bug(eventbus): intrinsic functions for eventbus name

### DIFF
--- a/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.js
+++ b/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.js
@@ -43,7 +43,7 @@ module.exports = {
               InputPath = eventRule.inputPath;
               Description = eventRule.description;
               Name = eventRule.name;
-              EventBusName = eventRule.eventBusName;
+              EventBusName = JSON.stringify(eventRule.eventBusName);
               IamRole = eventRule.iamRole;
 
               if (Input && InputPath) {
@@ -84,7 +84,7 @@ module.exports = {
               {
                 "Type": "AWS::Events::Rule",
                 "Properties": {
-                  ${EventBusName ? `"EventBusName": "${EventBusName}",` : ''}
+                  ${EventBusName ? `"EventBusName": ${EventBusName},` : ''}
                   "EventPattern": ${EventPattern.replace(/\\n|\\r/g, '')},
                   "State": "${State}",
                   ${Description ? `"Description": "${Description}",` : ''}

--- a/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.test.js
+++ b/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.test.js
@@ -297,6 +297,36 @@ describe('awsCompileCloudWatchEventEvents', () => {
         .Properties.EventBusName).to.equal('custom-event-bus');
     });
 
+    itParam('should respect eventBusName intrinsic function', ['cloudwatchEvent', 'eventBridge'], (source) => {
+      serverlessStepFunctions.serverless.service.stepFunctions = {
+        stateMachines: {
+          first: {
+            events: [
+              {
+                [source]: {
+                  event: {
+                    source: ['aws.ec2'],
+                    'detail-type': ['EC2 Instance State-change Notification'],
+                    detail: { state: ['pending'] },
+                  },
+                  enabled: false,
+                  input: '{"key":"value"}',
+                  name: 'test-event-name',
+                  eventBusName: '{"Fn::If": [isLocal, "develop", "production"}',
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      serverlessStepFunctions.compileCloudWatchEventEvents();
+
+      expect(serverlessStepFunctions.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleCloudWatchEvent1
+        .Properties.EventBusName).to.equal('{"Fn::If": [isLocal, "develop", "production"}');
+    });
+
     itParam('should respect input variable as an object', ['cloudwatchEvent', 'eventBridge'], (source) => {
       serverlessStepFunctions.serverless.service.stepFunctions = {
         stateMachines: {


### PR DESCRIPTION
If passed intrinsic functions the output is [object, object]. Using Stringify to fix this. fixes #404 