### PR TITLE
feat: add IAM Role support for createTransformJob.sync

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -286,6 +286,35 @@ function getCodeBuildPermissions(state) {
   }];
 }
 
+function getSageMakerPermissions(state) {
+  const transformJobName = state.Parameters.TransformJobName ? `${state.Parameters.TransformJobName}` : '';
+
+  return [
+    {
+      action: 'sagemaker:CreateTransformJob,sagemaker:DescribeTransformJob,sagemaker:StopTransformJob',
+      resource: {
+        'Fn::Sub': [
+          `arn:aws:sagemaker:$\{AWS::Region}:$\{AWS::AccountId}:transform-job/${transformJobName}*`,
+          {},
+        ],
+      },
+    },
+    {
+      action: 'sagemaker:ListTags',
+      resource: '*',
+    },
+    {
+      action: 'events:PutTargets,events:PutRule,events:DescribeRule',
+      resource: {
+        'Fn::Sub': [
+          'arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForSageMakerTransformJobsRule',
+          {},
+        ],
+      },
+    },
+  ];
+}
+
 // if there are multiple permissions with the same action, then collapsed them into one
 // permission instead, and collect the resources into an array
 function consolidatePermissionsByAction(permissions) {
@@ -369,6 +398,9 @@ function getIamPermissions(taskStates) {
       case 'arn:aws:states:::codebuild:startBuild':
       case 'arn:aws:states:::codebuild:startBuild.sync':
         return getCodeBuildPermissions(state);
+
+      case 'arn:aws:states:::sagemaker:createTransformJob.sync':
+        return getSageMakerPermissions(state);
 
       default:
         if (isIntrinsic(state.Resource) || state.Resource.startsWith('arn:aws:lambda')) {

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -2035,4 +2035,76 @@ describe('#compileIamRole', () => {
       '*limited*',
     ]);
   });
+
+  it('should give sagemaker batch transform permissions', () => {
+    const genStateMachine = id => ({
+      id,
+      definition: {
+        StartAt: 'A',
+        States: {
+          A: {
+            Type: 'Task',
+            Resource: 'arn:aws:states:::sagemaker:createTransformJob.sync',
+            Parameters: {
+              ModelName: 'a-model-name',
+              TransformInput: {
+                CompressionType: 'None',
+                ContentType: 'text/csv',
+                DataSource: {
+                  S3DataSource: {
+                    S3DataType: 'S3Prefix',
+                    S3Uri: 's3://your-bucket',
+                  },
+                },
+              },
+              TransformOutput: {
+                S3OutputPath: 's3://your-bucket/TrasformOutputPath',
+              },
+              TransformResources: {
+                InstanceCount: 1,
+                InstanceType: 'ml.m4.xlarge',
+              },
+              TransformJobName: 'your-job-name',
+            },
+            End: true,
+          },
+        },
+      },
+    });
+
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: genStateMachine('StateMachine1'),
+      },
+    };
+
+    serverlessStepFunctions.compileIamRole();
+    const statements = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources.StateMachine1Role
+      .Properties.Policies[0].PolicyDocument.Statement;
+
+    const transformPermissions = statements.filter(s => _.isEqual(s.Action, ['sagemaker:CreateTransformJob', 'sagemaker:DescribeTransformJob', 'sagemaker:StopTransformJob']));
+    expect(transformPermissions).to.have.lengthOf(1);
+    expect(transformPermissions[0].Resource).to.deep.eq([
+      {
+        'Fn::Sub': [
+          'arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:transform-job/your-job-name*',
+          {},
+        ],
+      },
+    ]);
+
+    const listTagPermission = statements.filter(s => _.isEqual(s.Action, ['sagemaker:ListTags']));
+    expect(listTagPermission).to.have.lengthOf(1);
+    expect(listTagPermission[0].Resource).to.equal('*');
+
+    const eventPermissions = statements.filter(s => _.isEqual(s.Action, ['events:PutTargets', 'events:PutRule', 'events:DescribeRule']));
+    expect(eventPermissions).to.has.lengthOf(1);
+    expect(eventPermissions[0].Resource).to.deep.eq([{
+      'Fn::Sub': [
+        'arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForSageMakerTransformJobsRule',
+        {},
+      ],
+    }]);
+  });
 });


### PR DESCRIPTION
Implements support for sagemaker createTransformJob.sync and resolves https://github.com/serverless-operations/serverless-step-functions/issues/385