### PR TITLE
fix: add required type parameter to cli options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -77,23 +77,28 @@ class ServerlessStepFunctions {
                 usage: 'The StateMachine name',
                 shortcut: 'n',
                 required: true,
+                type: 'string',
               },
               data: {
                 usage: 'String data to be passed as an event to your step function',
                 shortcut: 'd',
+                type: 'string',
               },
               path: {
                 usage:
                 'The path to a json file with input data to be passed to the invoked step function',
                 shortcut: 'p',
+                type: 'string',
               },
               stage: {
                 usage: 'Stage of the service',
                 shortcut: 's',
+                type: 'string',
               },
               region: {
                 usage: 'Region of the service',
                 shortcut: 'r',
+                type: 'string',
               },
             },
           },


### PR DESCRIPTION
Fixes deprecation `CLI_OPTIONS_SCHEMA` documented here: https://www.serverless.com/framework/docs/deprecations/

```text
Serverless: Deprecation warning: CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
             - ServerlessStepFunctions for "name", "data", "path", "stage", "region"
            Please report this issue in plugin issue tracker.
            Starting with next major release, this will be communicated with a thrown error.
            More Info: https://www.serverless.com/framework/docs/deprecations/#CLI_OPTIONS_SCHEMA
```

Fixes #415