### PR TITLE
Add json parsing to the console output

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -175,13 +175,25 @@ class ServerlessStepFunctions {
         if (result.status === 'FAILED') {
           return this.getExecutionHistory()
             .then((error) => {
-              this.serverless.cli.consoleLog(_.merge(result, error.events[error.events.length - 1]
-                .executionFailedEventDetails));
+              const errorMsg = _.merge(
+                result, 
+                error.events.find(ev => ev.type === 'ExecutionFailed')
+                  .executionFailedEventDetails
+              )
+              try {
+                this.serverless.cli.consoleLog(JSON.stringify(errorMsg, null, 2));
+              } catch (e) {
+                this.serverless.cli.consoleLog(errorMsg)
+              }
               process.exitCode = 1;
             });
         }
 
-        this.serverless.cli.consoleLog(result);
+        try {
+          this.serverless.cli.consoleLog(JSON.stringify(result, null, 2));
+        } catch (e) {
+          this.serverless.cli.consoleLog(result);
+        }
         return BbPromise.resolve();
       });
   }


### PR DESCRIPTION
This fixes the issue mentioned [here](https://github.com/serverless-operations/serverless-step-functions/issues/436).