### PR TITLE
Regognize API Gateway properties at `provider.apiGateway`

### DIFF
--- a/lib/deploy/events/apiGateway/apiKeys.js
+++ b/lib/deploy/events/apiGateway/apiKeys.js
@@ -5,12 +5,14 @@ const BbPromise = require('bluebird');
 
 module.exports = {
   compileApiKeys() {
-    if (this.serverless.service.provider.apiKeys) {
-      if (!Array.isArray(this.serverless.service.provider.apiKeys)) {
+    const apiKeys = _.get(this.serverless.service.provider.apiGateway, 'apiKeys')
+      || this.serverless.service.provider.apiKeys;
+    if (apiKeys) {
+      if (!Array.isArray(apiKeys)) {
         throw new this.serverless.classes.Error('apiKeys property must be an array');
       }
 
-      _.forEach(this.serverless.service.provider.apiKeys, (apiKey, i) => {
+      _.forEach(apiKeys, (apiKey, i) => {
         const apiKeyNumber = i + 1;
 
         if (typeof apiKey !== 'string') {

--- a/lib/deploy/events/apiGateway/apiKeys.test.js
+++ b/lib/deploy/events/apiGateway/apiKeys.test.js
@@ -16,7 +16,8 @@ describe('#methods()', () => {
       region: 'us-east-1',
     };
     serverless.setProvider('aws', new AwsProvider(serverless));
-    serverless.service.provider.apiKeys = ['1234567890'];
+    if (!serverless.service.provider.apiGateway) serverless.service.provider.apiGateway = {};
+    serverless.service.provider.apiGateway.apiKeys = ['1234567890'];
     serverless.service.provider.compiledCloudFormationTemplate = {
       Resources: {},
     };
@@ -79,12 +80,12 @@ describe('#methods()', () => {
   }));
 
   it('throw error if apiKey property is not an array', () => {
-    serverlessStepFunctions.serverless.service.provider.apiKeys = 2;
+    serverlessStepFunctions.serverless.service.provider.apiGateway.apiKeys = 2;
     expect(() => serverlessStepFunctions.compileApiKeys()).to.throw(Error);
   });
 
   it('throw error if an apiKey is not a string', () => {
-    serverlessStepFunctions.serverless.service.provider.apiKeys = [2];
+    serverlessStepFunctions.serverless.service.provider.apiGateway.apiKeys = [2];
     expect(() => serverlessStepFunctions.compileApiKeys()).to.throw(Error);
   });
 });

--- a/lib/deploy/events/apiGateway/restApi.js
+++ b/lib/deploy/events/apiGateway/restApi.js
@@ -43,10 +43,13 @@ module.exports = {
       },
     });
 
-    if (!_.isEmpty(this.serverless.service.provider.resourcePolicy)) {
+    const resourcePolicy = _.get(this.serverless.service.provider.apiGateway, 'resourcePolicy')
+      || this.serverless.service.provider.resourcePolicy;
+
+    if (!_.isEmpty(resourcePolicy)) {
       const policy = {
         Version: '2012-10-17',
-        Statement: this.serverless.service.provider.resourcePolicy,
+        Statement: resourcePolicy,
       };
       _.merge(this.serverless.service.provider.compiledCloudFormationTemplate
         .Resources[this.apiGatewayRestApiLogicalId].Properties, {

--- a/lib/deploy/events/apiGateway/restApi.test.js
+++ b/lib/deploy/events/apiGateway/restApi.test.js
@@ -89,19 +89,21 @@ describe('#compileRestApi()', () => {
   }));
 
   it('should create a REST API resource with resource policy', () => {
-    serverlessStepFunctions.serverless.service.provider.resourcePolicy = [
-      {
-        Effect: 'Allow',
-        Principal: '*',
-        Action: 'execute-api:Invoke',
-        Resource: ['execute-api:/*/*/*'],
-        Condition: {
-          IpAddress: {
-            'aws:SourceIp': ['123.123.123.123'],
+    serverlessStepFunctions.serverless.service.provider.apiGateway = {
+      resourcePolicy: [
+        {
+          Effect: 'Allow',
+          Principal: '*',
+          Action: 'execute-api:Invoke',
+          Resource: ['execute-api:/*/*/*'],
+          Condition: {
+            IpAddress: {
+              'aws:SourceIp': ['123.123.123.123'],
+            },
           },
         },
-      },
-    ];
+      ],
+    };
     return serverlessStepFunctions.compileRestApi().then(() => {
       expect(serverlessStepFunctions.serverless.service.provider
         .compiledCloudFormationTemplate.Resources).to.deep.equal(

--- a/lib/deploy/events/apiGateway/usagePlan.js
+++ b/lib/deploy/events/apiGateway/usagePlan.js
@@ -5,7 +5,9 @@ const BbPromise = require('bluebird');
 
 module.exports = {
   compileUsagePlan() {
-    if (this.serverless.service.provider.usagePlan
+    const usagePlan = _.get(this.serverless.service.provider.apiGateway, 'usagePlan')
+      || this.serverless.service.provider.usagePlan;
+    if (usagePlan
       || _.get(this.serverless.service.provider.apiGateway, 'apiKeys')
       || this.serverless.service.provider.apiKeys) {
       this.apiGatewayUsagePlanLogicalId = this.provider.naming.getUsagePlanLogicalId();
@@ -29,28 +31,26 @@ module.exports = {
           },
         },
       });
-      if (_.has(this.serverless.service.provider, 'usagePlan.quota')
-        && this.serverless.service.provider.usagePlan.quota !== null) {
+      if (_.has(usagePlan, 'quota') && usagePlan.quota !== null) {
         _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
           [this.apiGatewayUsagePlanLogicalId]: {
             Properties: {
               Quota: _.merge(
-                { Limit: this.serverless.service.provider.usagePlan.quota.limit },
-                { Offset: this.serverless.service.provider.usagePlan.quota.offset },
-                { Period: this.serverless.service.provider.usagePlan.quota.period },
+                { Limit: usagePlan.quota.limit },
+                { Offset: usagePlan.quota.offset },
+                { Period: usagePlan.quota.period },
               ),
             },
           },
         });
       }
-      if (_.has(this.serverless.service.provider, 'usagePlan.throttle')
-        && this.serverless.service.provider.usagePlan.throttle !== null) {
+      if (_.has(usagePlan, 'throttle') && usagePlan.throttle !== null) {
         _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
           [this.apiGatewayUsagePlanLogicalId]: {
             Properties: {
               Throttle: _.merge(
-                { BurstLimit: this.serverless.service.provider.usagePlan.throttle.burstLimit },
-                { RateLimit: this.serverless.service.provider.usagePlan.throttle.rateLimit },
+                { BurstLimit: usagePlan.throttle.burstLimit },
+                { RateLimit: usagePlan.throttle.rateLimit },
               ),
             },
           },

--- a/lib/deploy/events/apiGateway/usagePlan.js
+++ b/lib/deploy/events/apiGateway/usagePlan.js
@@ -5,7 +5,9 @@ const BbPromise = require('bluebird');
 
 module.exports = {
   compileUsagePlan() {
-    if (this.serverless.service.provider.usagePlan || this.serverless.service.provider.apiKeys) {
+    if (this.serverless.service.provider.usagePlan
+      || _.get(this.serverless.service.provider.apiGateway, 'apiKeys')
+      || this.serverless.service.provider.apiKeys) {
       this.apiGatewayUsagePlanLogicalId = this.provider.naming.getUsagePlanLogicalId();
       _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
         [this.apiGatewayUsagePlanLogicalId]: {

--- a/lib/deploy/events/apiGateway/usagePlan.test.js
+++ b/lib/deploy/events/apiGateway/usagePlan.test.js
@@ -84,15 +84,17 @@ describe('#compileUsagePlan()', () => {
   });
 
   it('should compile custom usage plan resource', () => {
-    serverless.service.provider.usagePlan = {
-      quota: {
-        limit: 500,
-        offset: 10,
-        period: 'MONTH',
-      },
-      throttle: {
-        burstLimit: 200,
-        rateLimit: 100,
+    serverless.service.provider.apiGateway = {
+      usagePlan: {
+        quota: {
+          limit: 500,
+          offset: 10,
+          period: 'MONTH',
+        },
+        throttle: {
+          burstLimit: 200,
+          rateLimit: 100,
+        },
       },
     };
 

--- a/lib/deploy/events/apiGateway/usagePlan.test.js
+++ b/lib/deploy/events/apiGateway/usagePlan.test.js
@@ -17,7 +17,8 @@ describe('#compileUsagePlan()', () => {
     };
     serverless.service.service = 'first-service';
     serverless.setProvider('aws', new AwsProvider(serverless));
-    serverless.service.provider.apiKeys = ['1234567890'];
+    if (!serverless.service.provider.apiGateway) serverless.service.provider.apiGateway = {};
+    serverless.service.provider.apiGateway.apiKeys = ['1234567890'];
     serverless.service.provider.compiledCloudFormationTemplate = {
       Resources: {},
     };
@@ -36,7 +37,7 @@ describe('#compileUsagePlan()', () => {
   });
 
   it('should compile default usage plan resource', () => {
-    serverless.service.provider.apiKeys = ['1234567890'];
+    serverless.service.provider.apiGateway.apiKeys = ['1234567890'];
     return serverlessStepFunctions.compileUsagePlan().then(() => {
       expect(
         serverlessStepFunctions.serverless.service.provider.compiledCloudFormationTemplate

--- a/lib/deploy/events/apiGateway/usagePlanKeys.js
+++ b/lib/deploy/events/apiGateway/usagePlanKeys.js
@@ -5,12 +5,14 @@ const BbPromise = require('bluebird');
 
 module.exports = {
   compileUsagePlanKeys() {
-    if (this.serverless.service.provider.apiKeys) {
-      if (!Array.isArray(this.serverless.service.provider.apiKeys)) {
+    const apiKeys = _.get(this.serverless.service.provider.apiGateway, 'apiKeys')
+      || this.serverless.service.provider.apiKeys;
+    if (apiKeys) {
+      if (!Array.isArray(apiKeys)) {
         throw new this.serverless.classes.Error('apiKeys property must be an array');
       }
 
-      _.forEach(this.serverless.service.provider.apiKeys, (apiKey, i) => {
+      _.forEach(apiKeys, (apiKey, i) => {
         const usagePlanKeyNumber = i + 1;
 
         if (typeof apiKey !== 'string') {

--- a/lib/deploy/events/apiGateway/usagePlanKeys.test.js
+++ b/lib/deploy/events/apiGateway/usagePlanKeys.test.js
@@ -19,7 +19,7 @@ describe('#compileUsagePlanKeys()', () => {
     serverless.service.service = 'first-service';
     serverless.service.provider = {
       name: 'aws',
-      apiKeys: ['1234567890'],
+      apiGateway: { apiKeys: ['1234567890'] },
     };
     serverless.service.provider.compiledCloudFormationTemplate = {
       Resources: {},
@@ -66,12 +66,12 @@ describe('#compileUsagePlanKeys()', () => {
   }));
 
   it('throw error if apiKey property is not an array', () => {
-    serverlessStepFunctions.serverless.service.provider.apiKeys = 2;
+    serverlessStepFunctions.serverless.service.provider.apiGateway.apiKeys = 2;
     expect(() => serverlessStepFunctions.compileUsagePlanKeys()).to.throw(Error);
   });
 
   it('throw error if an apiKey is not a string', () => {
-    serverlessStepFunctions.serverless.service.provider.apiKeys = [2];
+    serverlessStepFunctions.serverless.service.provider.apiGateway.apiKeys = [2];
     expect(() => serverlessStepFunctions.compileUsagePlanKeys()).to.throw(Error);
   });
 });


### PR DESCRIPTION
In the context of Serverless Framework, API Gateway specific properties as `apiKeys`, `resourcePolicy`, `usagePlan` were moved from `provider` context to `provider.apiGateway` context.

There's no plan to support old notation with a new major release of the Framework.

This PR ensures that the plugin will remain working without issues in v3 of the Framework

/cc @horike37 