### PR TITLE
fix: arn authorizers

### DIFF
--- a/lib/deploy/events/apiGateway/lambdaPermissions.js
+++ b/lib/deploy/events/apiGateway/lambdaPermissions.js
@@ -24,13 +24,15 @@ const BbPromise = require('bluebird');
 const getFunctionLogicalId = (uri) => {
   const parts = uri['Fn::Join'][1];
   const functionRef = parts.find(x => _.has(x, 'Fn::GetAtt'));
-  return functionRef['Fn::GetAtt'][0];
+  return _.get(functionRef, "['Fn::GetAtt'][0]", parts[parts.length - 2]);
 };
+
+const ARNRegex = /^arn:[^:\n]*:[^:\n]*:[^:\n]*:[^:\n]*:(?<resourceName>[^:/]*)[:/]?.*$/;
 
 const getLambdaPermission = logicalId => ({
   Type: 'AWS::Lambda::Permission',
   Properties: {
-    FunctionName: {
+    FunctionName: ARNRegex.test(logicalId) ? logicalId : {
       'Fn::GetAtt': [logicalId, 'Arn'],
     },
     Action: 'lambda:InvokeFunction',
@@ -54,7 +56,14 @@ module.exports = {
     }
 
     const lambdaPermissions = _.zipObject(
-      funcLogicalIds.map(id => `${id}LambdaPermission`),
+      funcLogicalIds.map((id) => {
+        if (ARNRegex.test(id)) {
+          const { groups: { resourceName } } = id.match(ARNRegex);
+          return `${resourceName}LambdaPermission`;
+        }
+
+        return `${id}LambdaPermission`;
+      }),
       funcLogicalIds.map(getLambdaPermission),
     );
 

--- a/lib/deploy/events/apiGateway/lambdaPermissions.test.js
+++ b/lib/deploy/events/apiGateway/lambdaPermissions.test.js
@@ -152,4 +152,55 @@ describe('#compileHttpLambdaPermissions()', () => {
       });
     });
   });
+
+  it('should create a Lambda Permission resource when there is an ARN authorizer', () => {
+    serverlessStepFunctions.serverless.service.provider
+      .compiledCloudFormationTemplate.Resources.HelloApiGatewayAuthorizer = {
+        Type: 'AWS::ApiGateway::Authorizer',
+        Properties: {
+          AuthorizerResultTtlInSeconds: 300,
+          IdentitySource: 'method.request.header.Authorization',
+          Name: 'hello',
+          RestApiId: {
+            Ref: 'ApiGatewayRestApi',
+          },
+          AuthorizerUri: {
+            'Fn::Join': [
+              '',
+              [
+                'arn:',
+                {
+                  Ref: 'AWS::Partition',
+                },
+                ':apigateway:',
+                {
+                  Ref: 'AWS::Region',
+                },
+                ':lambda:path/2015-03-31/functions/',
+                'arn:aws:lambda:us-east-1:000000000000:function:remote-authorizer',
+                '/invocations',
+              ],
+            ],
+          },
+          Type: 'TOKEN',
+        },
+      };
+
+    serverlessStepFunctions.compileHttpLambdaPermissions().then(() => {
+      const resources = serverlessStepFunctions.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources;
+      const lambdaPermissions = _.values(resources).filter(x => x.Type === 'AWS::Lambda::Permission');
+      expect(lambdaPermissions).to.have.lengthOf(1);
+      expect(lambdaPermissions[0]).to.deep.eq({
+        Type: 'AWS::Lambda::Permission',
+        Properties: {
+          FunctionName: 'arn:aws:lambda:us-east-1:000000000000:function:remote-authorizer',
+          Action: 'lambda:InvokeFunction',
+          Principal: {
+            'Fn::Sub': 'apigateway.${AWS::URLSuffix}',
+          },
+        },
+      });
+    });
+  });
 });


### PR DESCRIPTION
> This fixes issue #377 

## Description
Fixed an issue when using an arn for your authorizer rather than a function reference. I was getting the same issue when I was referencing a CloudFormation output variable and this PR fixes that case as well 😎