### PR TITLE
Replace "aws" with parititon ref

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const BbPromise = require('bluebird');
 const path = require('path');
 const { isIntrinsic, translateLocalFunctionNames, trimAliasFromLambdaArn } = require('../../utils/aws');
+const { getArnPartition } = require('../../utils/arn');
 
 function getTaskStates(states) {
   return _.flatMap(states, (state) => {
@@ -33,7 +34,8 @@ function sqsQueueUrlToArn(serverless, queueUrl) {
     const region = match[1];
     const accountId = match[2];
     const queueName = match[3];
-    return `arn:aws:sqs:${region}:${accountId}:${queueName}`;
+    const partition = getArnPartition(region);
+    return `arn:${partition}:sqs:${region}:${accountId}:${queueName}`;
   }
   if (isIntrinsic(queueUrl)) {
     if (queueUrl.Ref) {
@@ -91,7 +93,9 @@ function getDynamoDBArn(tableName) {
         'Fn::Join': [
           ':',
           [
-            'arn:aws:dynamodb',
+            'arn',
+            { Ref: 'AWS::Partition' },
+            'dynamodb',
             { Ref: 'AWS::Region' },
             { Ref: 'AWS::AccountId' },
             {
@@ -113,7 +117,9 @@ function getDynamoDBArn(tableName) {
     'Fn::Join': [
       ':',
       [
-        'arn:aws:dynamodb',
+        'arn',
+        { Ref: 'AWS::Partition' },
+        'dynamodb',
         { Ref: 'AWS::Region' },
         { Ref: 'AWS::AccountId' },
         `table/${tableName}`,
@@ -132,7 +138,9 @@ function getBatchPermissions() {
       'Fn::Join': [
         ':',
         [
-          'arn:aws:events',
+          'arn',
+          { Ref: 'AWS::Partition' },
+          'events',
           { Ref: 'AWS::Region' },
           { Ref: 'AWS::AccountId' },
           'rule/StepFunctionsGetEventsForBatchJobsRule',
@@ -159,7 +167,9 @@ function getEcsPermissions() {
       'Fn::Join': [
         ':',
         [
-          'arn:aws:events',
+          'arn',
+          { Ref: 'AWS::Partition' },
+          'events',
           { Ref: 'AWS::Region' },
           { Ref: 'AWS::AccountId' },
           'rule/StepFunctionsGetEventsForECSTaskRule',
@@ -188,7 +198,7 @@ function getLambdaPermissions(state) {
     const segments = functionName.split(':');
 
     let functionArns;
-    if (functionName.startsWith('arn:aws:lambda')) {
+    if (functionName.match(/^arn:aws(-[a-z]+)*:lambda/)) {
       // full ARN
       functionArns = [
         functionName,
@@ -197,17 +207,17 @@ function getLambdaPermissions(state) {
     } else if (segments.length === 3 && segments[0].match(/^\d+$/)) {
       // partial ARN
       functionArns = [
-        { 'Fn::Sub': `arn:aws:lambda:\${AWS::Region}:${functionName}` },
-        { 'Fn::Sub': `arn:aws:lambda:\${AWS::Region}:${functionName}:*` },
+        { 'Fn::Sub': `arn:\${AWS::Partition}:lambda:\${AWS::Region}:${functionName}` },
+        { 'Fn::Sub': `arn:\${AWS::Partition}:lambda:\${AWS::Region}:${functionName}:*` },
       ];
     } else {
       // name-only (with or without alias)
       functionArns = [
         {
-          'Fn::Sub': `arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:${functionName}`,
+          'Fn::Sub': `arn:\${AWS::Partition}:lambda:\${AWS::Region}:\${AWS::AccountId}:function:${functionName}`,
         },
         {
-          'Fn::Sub': `arn:aws:lambda:\${AWS::Region}:\${AWS::AccountId}:function:${functionName}:*`,
+          'Fn::Sub': `arn:\${AWS::Partition}:lambda:\${AWS::Region}:\${AWS::AccountId}:function:${functionName}:*`,
         },
       ];
     }
@@ -236,13 +246,13 @@ function getLambdaPermissions(state) {
       resource: [
         {
           'Fn::Sub': [
-            'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionArn}',
+            'arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionArn}',
             { functionArn },
           ],
         },
         {
           'Fn::Sub': [
-            'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionArn}:*',
+            'arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionArn}:*',
             { functionArn },
           ],
         },
@@ -282,7 +292,7 @@ function getStepFunctionsPermissions(state) {
     action: 'events:PutTargets,events:PutRule,events:DescribeRule',
     resource: {
       'Fn::Sub': [
-        'arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule',
+        'arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule',
         {},
       ],
     },
@@ -296,7 +306,7 @@ function getCodeBuildPermissions(state) {
     action: 'codebuild:StartBuild,codebuild:StopBuild,codebuild:BatchGetBuilds',
     resource: {
       'Fn::Sub': [
-        `arn:aws:codebuild:$\{AWS::Region}:$\{AWS::AccountId}:project/${projectName}`,
+        `arn:\${AWS::Partition}:codebuild:$\{AWS::Region}:$\{AWS::AccountId}:project/${projectName}`,
         {},
       ],
     },
@@ -304,7 +314,7 @@ function getCodeBuildPermissions(state) {
     action: 'events:PutTargets,events:PutRule,events:DescribeRule',
     resource: {
       'Fn::Sub': [
-        'arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventForCodeBuildStartBuildRule',
+        'arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventForCodeBuildStartBuildRule',
         {},
       ],
     },
@@ -319,7 +329,7 @@ function getSageMakerPermissions(state) {
       action: 'sagemaker:CreateTransformJob,sagemaker:DescribeTransformJob,sagemaker:StopTransformJob',
       resource: {
         'Fn::Sub': [
-          `arn:aws:sagemaker:$\{AWS::Region}:$\{AWS::AccountId}:transform-job/${transformJobName}*`,
+          `arn:\${AWS::Partition}:sagemaker:$\{AWS::Region}:$\{AWS::AccountId}:transform-job/${transformJobName}*`,
           {},
         ],
       },
@@ -332,7 +342,7 @@ function getSageMakerPermissions(state) {
       action: 'events:PutTargets,events:PutRule,events:DescribeRule',
       resource: {
         'Fn::Sub': [
-          'arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForSageMakerTransformJobsRule',
+          'arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForSageMakerTransformJobsRule',
           {},
         ],
       },
@@ -352,7 +362,7 @@ function getEventBridgePermissions(state) {
       action: 'events:PutEvents',
       resource: [...eventBuses].map(eventBus => ({
         'Fn::Sub': [
-          'arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/${eventBus}',
+          'arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/${eventBus}',
           { eventBus },
         ],
       })),
@@ -399,7 +409,8 @@ function consolidatePermissionsByResource(permissions) {
 
 function getIamPermissions(taskStates) {
   return _.flatMap(taskStates, (state) => {
-    switch (state.Resource) {
+    const resourceName = typeof state.Resource === 'string' ? state.Resource.replace(/^arn:aws(-[a-z]+)*:/, 'arn:aws:') : state.Resource;
+    switch (resourceName) {
       case 'arn:aws:states:::sqs:sendMessage':
       case 'arn:aws:states:::sqs:sendMessage.waitForTaskToken':
         return getSqsPermissions(this.serverless, state);
@@ -452,7 +463,7 @@ function getIamPermissions(taskStates) {
         return getEventBridgePermissions(state);
 
       default:
-        if (isIntrinsic(state.Resource) || state.Resource.startsWith('arn:aws:lambda')) {
+        if (isIntrinsic(state.Resource) || !!state.Resource.match(/arn:aws(-[a-z]+)*:lambda/)) {
           const trimmedArn = trimAliasFromLambdaArn(state.Resource);
           const functionArn = translateLocalFunctionNames.bind(this)(trimmedArn);
           return [{

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -296,6 +296,8 @@ describe('#compileIamRole', () => {
     const helloQueueArn = 'arn:aws:sqs:#{AWS::Region}:#{AWS::AccountId}:hello';
     const worldQueue = 'https://sqs.us-east-1.amazonaws.com/#{AWS::AccountId}/world';
     const worldQueueArn = 'arn:aws:sqs:us-east-1:#{AWS::AccountId}:world';
+    const govQueue = 'https://sqs.us-gov-east-1.amazonaws.com/#{AWS::AccountId}/cloudGov';
+    const govQueueArn = 'arn:aws-us-gov:sqs:us-gov-east-1:#{AWS::AccountId}:cloudGov';
 
     const genStateMachine = (id, queueUrl) => ({
       id,
@@ -319,6 +321,7 @@ describe('#compileIamRole', () => {
       stateMachines: {
         myStateMachine1: genStateMachine('StateMachine1', helloQueue),
         myStateMachine2: genStateMachine('StateMachine2', worldQueue),
+        myStateMachine3: genStateMachine('StateMachine3', govQueue),
       },
     };
 
@@ -327,10 +330,13 @@ describe('#compileIamRole', () => {
       .provider.compiledCloudFormationTemplate.Resources;
     const policy1 = resources.StateMachine1Role.Properties.Policies[0];
     const policy2 = resources.StateMachine2Role.Properties.Policies[0];
+    const policy3 = resources.StateMachine3Role.Properties.Policies[0];
     expect(policy1.PolicyDocument.Statement[0].Resource)
       .to.be.deep.equal([helloQueueArn]);
     expect(policy2.PolicyDocument.Statement[0].Resource)
       .to.be.deep.equal([worldQueueArn]);
+    expect(policy3.PolicyDocument.Statement[0].Resource)
+      .to.be.deep.equal([govQueueArn]);
   });
 
   it('should give sqs:SendMessage permission to * whenever QueueUrl.$ is seen', () => {
@@ -496,13 +502,13 @@ describe('#compileIamRole', () => {
     const helloTable = 'hello';
     const helloTableArn = {
       'Fn::Join': [
-        ':', ['arn:aws:dynamodb', { Ref: 'AWS::Region' }, { Ref: 'AWS::AccountId' }, 'table/hello'],
+        ':', ['arn', { Ref: 'AWS::Partition' }, 'dynamodb', { Ref: 'AWS::Region' }, { Ref: 'AWS::AccountId' }, 'table/hello'],
       ],
     };
     const worldTable = 'world';
     const worldTableArn = {
       'Fn::Join': [
-        ':', ['arn:aws:dynamodb', { Ref: 'AWS::Region' }, { Ref: 'AWS::AccountId' }, 'table/world'],
+        ':', ['arn', { Ref: 'AWS::Partition' }, 'dynamodb', { Ref: 'AWS::Region' }, { Ref: 'AWS::AccountId' }, 'table/world'],
       ],
     };
 
@@ -577,17 +583,18 @@ describe('#compileIamRole', () => {
   });
 
   it('should give dynamodb permission for table name imported from external stack', () => {
+    // Necessary to convince the region is in the gov cloud infrastructure.
     const externalHelloTable = { 'Fn::ImportValue': 'HelloStack:Table:Name' };
     const helloTableArn = {
       'Fn::Join': [
-        ':', ['arn:aws:dynamodb', { Ref: 'AWS::Region' }, { Ref: 'AWS::AccountId' }, { 'Fn::Join': ['/', ['table', externalHelloTable]] }],
+        ':', ['arn', { Ref: 'AWS::Partition' }, 'dynamodb', { Ref: 'AWS::Region' }, { Ref: 'AWS::AccountId' }, { 'Fn::Join': ['/', ['table', externalHelloTable]] }],
       ],
     };
 
     const externalWorldTable = { 'Fn::ImportValue': 'WorldStack:Table:Name' };
     const worldTableArn = {
       'Fn::Join': [
-        ':', ['arn:aws:dynamodb', { Ref: 'AWS::Region' }, { Ref: 'AWS::AccountId' }, { 'Fn::Join': ['/', ['table', externalWorldTable]] }],
+        ':', ['arn', { Ref: 'AWS::Partition' }, 'dynamodb', { Ref: 'AWS::Region' }, { Ref: 'AWS::AccountId' }, { 'Fn::Join': ['/', ['table', externalWorldTable]] }],
       ],
     };
 
@@ -640,6 +647,7 @@ describe('#compileIamRole', () => {
     };
 
     serverlessStepFunctions.compileIamRole();
+
     const resources = serverlessStepFunctions.serverless.service
       .provider.compiledCloudFormationTemplate.Resources;
     const policy1 = resources.StateMachine1Role.Properties.Policies[0];
@@ -749,7 +757,9 @@ describe('#compileIamRole', () => {
       'Fn::Join': [
         ':',
         [
-          'arn:aws:events',
+          'arn',
+          { Ref: 'AWS::Partition' },
+          'events',
           { Ref: 'AWS::Region' },
           { Ref: 'AWS::AccountId' },
           'rule/StepFunctionsGetEventsForBatchJobsRule',
@@ -836,7 +846,9 @@ describe('#compileIamRole', () => {
       'Fn::Join': [
         ':',
         [
-          'arn:aws:events',
+          'arn',
+          { Ref: 'AWS::Partition' },
+          'events',
           { Ref: 'AWS::Region' },
           { Ref: 'AWS::AccountId' },
           'rule/StepFunctionsGetEventsForECSTaskRule',
@@ -935,12 +947,12 @@ describe('#compileIamRole', () => {
 
     const dynamodbArn1 = {
       'Fn::Join': [
-        ':', ['arn:aws:dynamodb', { Ref: 'AWS::Region' }, { Ref: 'AWS::AccountId' }, 'table/foo'],
+        ':', ['arn', { Ref: 'AWS::Partition' }, 'dynamodb', { Ref: 'AWS::Region' }, { Ref: 'AWS::AccountId' }, 'table/foo'],
       ],
     };
     const dynamodbArn2 = {
       'Fn::Join': [
-        ':', ['arn:aws:dynamodb', { Ref: 'AWS::Region' }, { Ref: 'AWS::AccountId' }, 'table/bar'],
+        ':', ['arn', { Ref: 'AWS::Partition' }, 'dynamodb', { Ref: 'AWS::Region' }, { Ref: 'AWS::AccountId' }, 'table/bar'],
       ],
     };
 
@@ -1287,7 +1299,9 @@ describe('#compileIamRole', () => {
         'Fn::Join': [
           ':',
           [
-            'arn:aws:events',
+            'arn',
+            { Ref: 'AWS::Partition' },
+            'events',
             { Ref: 'AWS::Region' },
             { Ref: 'AWS::AccountId' },
             'rule/StepFunctionsGetEventsForECSTaskRule',
@@ -1310,14 +1324,14 @@ describe('#compileIamRole', () => {
     };
 
     const lambdaArns1 = [
-      { 'Fn::Sub': 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:a' },
-      { 'Fn::Sub': 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:b:v1' },
+      { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:a' },
+      { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:b:v1' },
     ];
     expectation(policy1, lambdaArns1, sns1, sqsArn1);
 
     const lambdaArns2 = [
       'arn:aws:lambda:us-west-2:1234567890:function:c',
-      { 'Fn::Sub': 'arn:aws:lambda:${AWS::Region}:1234567890:function:d' },
+      { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:${AWS::Region}:1234567890:function:d' },
     ];
     expectation(policy2, lambdaArns2, sns2, sqsArn2);
   });
@@ -1376,10 +1390,10 @@ describe('#compileIamRole', () => {
       expect(lambdaPermissions[0].Resource).to.deep.include(lambdaArn);
     };
 
-    expectation(policy1, { 'Fn::Sub': 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:a' });
-    expectation(policy2, { 'Fn::Sub': 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:b:v1' });
+    expectation(policy1, { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:a' });
+    expectation(policy2, { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:b:v1' });
     expectation(policy3, 'arn:aws:lambda:us-west-2:1234567890:function:c');
-    expectation(policy4, { 'Fn::Sub': 'arn:aws:lambda:${AWS::Region}:1234567890:function:d' });
+    expectation(policy4, { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:${AWS::Region}:1234567890:function:d' });
   });
 
   it('should support intrinsic functions for lambda::invoke resource type', () => {
@@ -1408,7 +1422,7 @@ describe('#compileIamRole', () => {
     const lambda2 = { 'Fn::GetAtt': ['MyFunction', 'Arn'] }; // Arn
     const lambda3 = { // or, something we don't need special handling for
       'Fn::Sub': [
-        'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${FunctionName}',
+        'arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${FunctionName}',
         {
           FunctionName: 'myFunction',
         },
@@ -1441,7 +1455,7 @@ describe('#compileIamRole', () => {
 
     const lambdaArn1 = {
       'Fn::Sub': [
-        'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionArn}',
+        'arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionArn}',
         { functionArn: lambda1 },
       ],
     };
@@ -1457,7 +1471,7 @@ describe('#compileIamRole', () => {
 
     const lambdaArn3 = {
       'Fn::Sub': [
-        'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${FunctionName}',
+        'arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${FunctionName}',
         {
           FunctionName: 'myFunction',
         },
@@ -1568,7 +1582,7 @@ describe('#compileIamRole', () => {
     const lambdaArns = [
       {
         'Fn::Sub': [
-          'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionArn}',
+          'arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionArn}',
           { functionArn: { Ref: 'HelloDashworldLambdaFunction' } },
         ],
       },
@@ -1686,7 +1700,7 @@ describe('#compileIamRole', () => {
     expect(codeBuildPermissions).to.have.lengthOf(1);
     expect(codeBuildPermissions[0].Resource).to.deep.eq([{
       'Fn::Sub': [
-        `arn:aws:codebuild:$\{AWS::Region}:$\{AWS::AccountId}:project/${projectName}`,
+        `arn:\${AWS::Partition}:codebuild:$\{AWS::Region}:$\{AWS::AccountId}:project/${projectName}`,
         {},
       ],
     }]);
@@ -1696,7 +1710,7 @@ describe('#compileIamRole', () => {
     expect(eventPermissions).to.have.lengthOf(1);
     expect(eventPermissions[0].Resource).to.deep.eq([{
       'Fn::Sub': [
-        'arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventForCodeBuildStartBuildRule',
+        'arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventForCodeBuildStartBuildRule',
         {},
       ],
     }]);
@@ -1772,7 +1786,7 @@ describe('#compileIamRole', () => {
     expect(eventPermissions).to.have.lengthOf(1);
     expect(eventPermissions[0].Resource).to.deep.eq([{
       'Fn::Sub': [
-        'arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule',
+        'arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule',
         {},
       ],
     }]);
@@ -2173,7 +2187,7 @@ describe('#compileIamRole', () => {
     expect(transformPermissions[0].Resource).to.deep.eq([
       {
         'Fn::Sub': [
-          'arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:transform-job/your-job-name*',
+          'arn:${AWS::Partition}:sagemaker:${AWS::Region}:${AWS::AccountId}:transform-job/your-job-name*',
           {},
         ],
       },
@@ -2187,7 +2201,7 @@ describe('#compileIamRole', () => {
     expect(eventPermissions).to.has.lengthOf(1);
     expect(eventPermissions[0].Resource).to.deep.eq([{
       'Fn::Sub': [
-        'arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForSageMakerTransformJobsRule',
+        'arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForSageMakerTransformJobsRule',
         {},
       ],
     }]);
@@ -2229,7 +2243,7 @@ describe('#compileIamRole', () => {
     expect(eventPermissions).to.has.lengthOf(1);
     expect(eventPermissions[0].Resource).to.deep.eq([{
       'Fn::Sub': [
-        'arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/${eventBus}',
+        'arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/${eventBus}',
         { eventBus: 'default' },
       ],
     }]);
@@ -2280,13 +2294,13 @@ describe('#compileIamRole', () => {
     expect(eventPermissions[0].Resource).to.deep.eq([
       {
         'Fn::Sub': [
-          'arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/${eventBus}',
+          'arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/${eventBus}',
           { eventBus: 'default' },
         ],
       },
       {
         'Fn::Sub': [
-          'arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/${eventBus}',
+          'arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/${eventBus}',
           { eventBus: 'custom' },
         ],
       },

--- a/lib/utils/arm.test.js
+++ b/lib/utils/arm.test.js
@@ -1,0 +1,21 @@
+const expect = require('chai').expect;
+const ArnUtils = require('./arn');
+
+describe('#arnUtils', () => {
+  describe('#getArnPartition', () => {
+    it('should return aws-us-gov partition for Gov Cloud regions.', () => {
+      expect(ArnUtils.getArnPartition('us-gov-east-1')).to.equal('aws-us-gov');
+      expect(ArnUtils.getArnPartition('us-gov-west-1')).to.equal('aws-us-gov');
+    });
+
+    it('should return aws-cn for chinese AWS regions', () => {
+      expect(ArnUtils.getArnPartition('cn-north-1')).to.equal('aws-cn');
+      expect(ArnUtils.getArnPartition('cn-northwest-1')).to.equal('aws-cn');
+    });
+
+    it('should return aws for standard AWS regions', () => {
+      expect(ArnUtils.getArnPartition('us-east-1')).to.equal('aws');
+      expect(ArnUtils.getArnPartition('ap-east-1')).to.equal('aws');
+    });
+  });
+});

--- a/lib/utils/arn.js
+++ b/lib/utils/arn.js
@@ -1,0 +1,27 @@
+/**
+ *
+ * Returns the proper partition that is placed in an ARN.
+ *
+ * Examples:
+ *
+ * 'arn:aws:<rest of ARN>'
+ * 'arn:aws-us-gov:<rest of ARN>'
+ *
+ * The 'aws' and 'aws-gov' are the partitions
+ *
+ * @param region - The region that the application is deploying to
+ * @returns The proper partition for the given region.
+ */
+function getArnPartition(region) {
+  if (region.startsWith('us-gov')) {
+    return 'aws-us-gov';
+  }
+  if (region.startsWith('cn-')) {
+    return 'aws-cn';
+  }
+  return 'aws';
+}
+
+module.exports = {
+  getArnPartition,
+};

--- a/lib/utils/aws.js
+++ b/lib/utils/aws.js
@@ -77,7 +77,7 @@ function convertToFunctionVersion(value) {
 
 // If the resource is a lambda ARN string, trim off the alias
 function trimAliasFromLambdaArn(resource) {
-  if (typeof resource === 'string' && resource.startsWith('arn:aws:lambda')) {
+  if (typeof resource === 'string' && !!resource.match(/^arn:aws(-[a-z]+)*:lambda/)) {
     const components = resource.split(':');
     // Lambda ARNs with an alias have 8 components
     // E.g. arn:aws:lambda:region:accountId:function:name:alias

--- a/lib/utils/aws.test.js
+++ b/lib/utils/aws.test.js
@@ -1,0 +1,38 @@
+const expect = require('chai').expect;
+const AwsUtils = require('./aws');
+
+describe('#awsUtils', () => {
+  describe('#trimAliasFromLambdaArn', () => {
+    it('should return the resource if it is an intrinsic function', () => {
+      const resource = {
+        'Fn::Sub': 'arn:aws:lambda:us-east-1:1111:function:testLambda',
+      };
+      expect(AwsUtils.trimAliasFromLambdaArn(resource)).to.equal(resource);
+    });
+
+    it('should return the resource if it is not a lambda arn', () => {
+      const resource = 'arn:aws:dynamodb:us-east-1:1111:table/testTable';
+      expect(AwsUtils.trimAliasFromLambdaArn(resource)).to.equal('arn:aws:dynamodb:us-east-1:1111:table/testTable');
+    });
+
+    it('should return the lambda arn if is not aliased.', () => {
+      const resource = 'arn:aws:lambda:us-east-1:1111:function:testLambda:testLambda';
+      expect(AwsUtils.trimAliasFromLambdaArn(resource)).to.equal('arn:aws:lambda:us-east-1:1111:function:testLambda');
+    });
+
+    it('should trim off the alias from the lambda ARN.', () => {
+      const resource = 'arn:aws:lambda:us-east-1:1111:function:testLambda:testAlias';
+      expect(AwsUtils.trimAliasFromLambdaArn(resource)).to.equal('arn:aws:lambda:us-east-1:1111:function:testLambda');
+    });
+
+    it('should trim off the alias from the lambda gov cloud ARN.', () => {
+      const resource = 'arn:aws-us-gov:lambda:us-east-1:1111:function:testLambda:testAlias';
+      expect(AwsUtils.trimAliasFromLambdaArn(resource)).to.equal('arn:aws-us-gov:lambda:us-east-1:1111:function:testLambda');
+    });
+
+    it('should trim off the alias from the lambda Chinese ARN.', () => {
+      const resource = 'arn:aws-cn:lambda:us-east-1:1111:function:testLambda:testAlias';
+      expect(AwsUtils.trimAliasFromLambdaArn(resource)).to.equal('arn:aws-cn:lambda:us-east-1:1111:function:testLambda');
+    });
+  });
+});


### PR DESCRIPTION
This adds AWS Gov Cloud support (and possibly China support) by replacing the generic "aws" reference to the `{ Ref: "Partition" }` CloudFormation psuedo-parameter.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-partition