### PR TITLE
Mark plugin as Serverless Framework v3 ready

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lodash": "^4.17.11"
   },
   "peerDependencies": {
-    "serverless": "^2.32.0"
+    "serverless": "^2.32.0 || 3"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Plugin is confirmed to work with v3 release without issues, therefore it'll be good whitelist v3 of the Framework in peer dependencies section