### PR TITLE
feat(alarm): support for custom alarm names

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,71 @@ alarms:
   treatMissingData: ignore # default
 ```
 
+#### Custom CloudWatch Alarm names
+
+By default, the CloudFormation assigns names to the alarms based on the CloudFormation stack and the resource logical Id, and in some cases and these names could be confusing.
+
+To use custom names to the alarms add `nameTemplate` property in the `alarms` object.
+
+example:
+
+```yaml
+service: myservice
+
+plugins:
+  - serverless-step-functions
+
+stepFunctions:
+  stateMachines:
+    main-workflow:
+      name: main
+      alarms:
+        nameTemplate: $[stateMachineName]-$[cloudWatchMetricName]-alarm
+        topics:
+          alarm: !Ref AwsAlertsGenericAlarmTopicAlarm
+        metrics:
+          - executionsFailed
+          - executionsAborted
+          - executionsTimedOut
+          - executionThrottled
+        treatMissingData: ignore
+      definition: ${file(./step-functions/main.asl.yaml)}
+```
+
+Supported variables to the `nameTemplate` property:
+
+- `stateMachineName`
+- `metricName`
+- `cloudWatchMetricName`
+
+##### Per-Metric Alarm Name
+
+To overwrite the alarm name for a specific metric, add the `alarmName` property in the metric object.
+
+```yaml
+service: myservice
+
+plugins:
+  - serverless-step-functions
+
+stepFunctions:
+  stateMachines:
+    main-workflow:
+      name: main
+      alarms:
+        nameTemplate: $[stateMachineName]-$[cloudWatchMetricName]-alarm
+        topics:
+          alarm: !Ref AwsAlertsGenericAlarmTopicAlarm
+        metrics:
+          - metric: executionsFailed
+            alarmName: mycustom-name-${self:stage.region}-Failed-alarm
+          - executionsAborted
+          - executionsTimedOut
+          - executionThrottled
+        treatMissingData: ignore
+      definition: ${file(./step-functions/main.asl.yaml)}
+```
+
 ### CloudWatch Notifications
 
 You can monitor the execution state of your state machines [via CloudWatch Events](https://aws.amazon.com/about-aws/whats-new/2019/05/aws-step-functions-adds-support-for-workflow-execution-events/). It allows you to be alerted when the status of your state machine changes to `ABORTED`, `FAILED`, `RUNNING`, `SUCCEEDED` or `TIMED_OUT`.

--- a/lib/deploy/stepFunctions/compileAlarms.js
+++ b/lib/deploy/stepFunctions/compileAlarms.js
@@ -22,6 +22,39 @@ const alarmDescriptions = {
   executionsSucceeded: 'executions succeeded',
 };
 
+const supportedVariables = [
+  'stateMachineName',
+  'cloudWatchMetricName',
+  'metricName',
+];
+const variableRegxPattern = /(?<=\$\[)[^\][]*(?=])/g;
+
+function getAlarmNameFromTemplate(nameTemplate, variables) {
+  let alarmName = null;
+  if (!_.isNil(nameTemplate)) {
+    const matches = nameTemplate.match(variableRegxPattern);
+    let validVariables = true;
+    for (const match of matches) {
+      if (!supportedVariables.includes(match)) {
+        logger.log(
+          `Invalid alarms.nameTemplate property, variable '${match}' `
+          + `does not match with the supported variables: ${supportedVariables.join(', ')}`,
+        );
+        validVariables = false;
+      }
+    }
+
+    if (validVariables) {
+      alarmName = nameTemplate;
+      for (const match of matches) {
+        alarmName = alarmName.replace(`$[${match}]`, variables[match]);
+      }
+    }
+  }
+
+  return alarmName;
+}
+
 function getCloudWatchAlarms(
   serverless, region, stage, stateMachineName, stateMachineLogicalId, alarmsObj,
 ) {
@@ -32,6 +65,7 @@ function getCloudWatchAlarms(
   const insufficientDataAction = _.get(alarmsObj, 'topics.insufficientData');
   const insufficientDataActions = insufficientDataAction ? [insufficientDataAction] : [];
   const defaultTreatMissingData = _.get(alarmsObj, 'treatMissingData', 'missing');
+  const nameTemplate = _.get(alarmsObj, 'nameTemplate', null);
 
   const metrics = _.uniq(_.get(alarmsObj, 'metrics', []));
   const [valid, invalid] = _.partition(
@@ -57,7 +91,15 @@ function getCloudWatchAlarms(
     const logicalId = _.get(metric, 'logicalId', defaultLogicalId);
     const treatMissingData = _.get(metric, 'treatMissingData', defaultTreatMissingData);
 
-    return {
+    const templateAlarmName = getAlarmNameFromTemplate(nameTemplate, {
+      metricName,
+      cloudWatchMetricName,
+      stateMachineName,
+    });
+
+    const alarmName = _.get(metric, 'alarmName', templateAlarmName);
+
+    const cfnResource = {
       logicalId,
       alarm: {
         Type: 'AWS::CloudWatch::Alarm',
@@ -85,6 +127,12 @@ function getCloudWatchAlarms(
         },
       },
     };
+
+    if (alarmName) {
+      cfnResource.alarm.Properties.AlarmName = alarmName;
+    }
+
+    return cfnResource;
   });
 }
 

--- a/lib/deploy/stepFunctions/compileAlarms.schema.js
+++ b/lib/deploy/stepFunctions/compileAlarms.schema.js
@@ -44,6 +44,7 @@ const simpleMetric = Joi.string()
 const complexMetric = Joi.object().keys({
   metric: simpleMetric.required(),
   logicalId: Joi.string(),
+  alarmName: Joi.string(),
   treatMissingData,
 });
 
@@ -54,9 +55,12 @@ const metric = Joi.alternatives().try(
 
 const metrics = Joi.array().items(metric).min(1);
 
+const nameTemplate = Joi.string();
+
 const schema = Joi.object().keys({
   topics: topics.required(),
   metrics: metrics.required(),
+  nameTemplate,
   treatMissingData,
 });
 

--- a/lib/deploy/stepFunctions/compileAlarms.test.js
+++ b/lib/deploy/stepFunctions/compileAlarms.test.js
@@ -426,4 +426,157 @@ describe('#compileAlarms', () => {
     expect(resources).to.have.property('MyAlarm');
     expect(consoleLogSpy.callCount).equal(0);
   });
+
+  it('should generate CloudWatch Alarms with nameTemplate', () => {
+    const genStateMachine = name => ({
+      name,
+      definition: {
+        StartAt: 'A',
+        States: {
+          A: {
+            Type: 'Pass',
+            End: true,
+          },
+        },
+      },
+      alarms: {
+        topics: {
+          ok: '${self:service}-${opt:stage}-alerts-ok',
+          alarm: '${self:service}-${opt:stage}-alerts-alarm',
+          insufficientData: '${self:service}-${opt:stage}-alerts-missing',
+        },
+        nameTemplate: '$[stateMachineName]-$[cloudWatchMetricName]-alarm',
+        metrics: [
+          'executionsTimedOut',
+          'executionsFailed',
+          'executionsAborted',
+          'executionThrottled',
+          'executionsSucceeded',
+        ],
+      },
+    });
+
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine: genStateMachine('stateCustomName1'),
+      },
+    };
+
+    serverlessStepFunctions.compileAlarms();
+    const resources = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources;
+
+    expect(resources.StateCustomName1ExecutionsTimedOutAlarm.Properties.AlarmName).to.be.equal('stateCustomName1-ExecutionsTimedOut-alarm');
+    validateCloudWatchAlarm(resources.StateCustomName1ExecutionsTimedOutAlarm);
+    expect(resources.StateCustomName1ExecutionsFailedAlarm.Properties.AlarmName).to.be.equal('stateCustomName1-ExecutionsFailed-alarm');
+    validateCloudWatchAlarm(resources.StateCustomName1ExecutionsFailedAlarm);
+    expect(resources.StateCustomName1ExecutionsAbortedAlarm.Properties.AlarmName).to.be.equal('stateCustomName1-ExecutionsAborted-alarm');
+    validateCloudWatchAlarm(resources.StateCustomName1ExecutionsAbortedAlarm);
+    expect(resources.StateCustomName1ExecutionThrottledAlarm.Properties.AlarmName).to.be.equal('stateCustomName1-ExecutionThrottled-alarm');
+    validateCloudWatchAlarm(resources.StateCustomName1ExecutionThrottledAlarm);
+    expect(consoleLogSpy.callCount).equal(0);
+  });
+
+  it('should generate CloudWatch Alarms with invalid nameTemplate', () => {
+    const genStateMachine = name => ({
+      name,
+      definition: {
+        StartAt: 'A',
+        States: {
+          A: {
+            Type: 'Pass',
+            End: true,
+          },
+        },
+      },
+      alarms: {
+        topics: {
+          ok: '${self:service}-${opt:stage}-alerts-ok',
+          alarm: '${self:service}-${opt:stage}-alerts-alarm',
+          insufficientData: '${self:service}-${opt:stage}-alerts-missing',
+        },
+        nameTemplate: '$[stateMachineName]-$[invalidProp]-alarm',
+        metrics: [
+          'executionsTimedOut',
+          'executionsFailed',
+          'executionsAborted',
+          'executionThrottled',
+          'executionsSucceeded',
+        ],
+      },
+    });
+
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine: genStateMachine('stateCustomName2'),
+      },
+    };
+
+    serverlessStepFunctions.compileAlarms();
+    const resources = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources;
+
+    expect(resources.StateCustomName2ExecutionsTimedOutAlarm.Properties).not.have.property('AlarmName');
+    validateCloudWatchAlarm(resources.StateCustomName2ExecutionsTimedOutAlarm);
+    expect(resources.StateCustomName2ExecutionsFailedAlarm.Properties).not.have.property('AlarmName');
+    validateCloudWatchAlarm(resources.StateCustomName2ExecutionsFailedAlarm);
+    expect(resources.StateCustomName2ExecutionsAbortedAlarm.Properties).not.have.property('AlarmName');
+    validateCloudWatchAlarm(resources.StateCustomName2ExecutionsAbortedAlarm);
+    expect(resources.StateCustomName2ExecutionThrottledAlarm.Properties).not.have.property('AlarmName');
+    validateCloudWatchAlarm(resources.StateCustomName2ExecutionThrottledAlarm);
+    expect(consoleLogSpy.callCount).equal(5);
+  });
+
+  it('should generate CloudWatch Alarms with custom alarm name', () => {
+    const genStateMachine = name => ({
+      name,
+      definition: {
+        StartAt: 'A',
+        States: {
+          A: {
+            Type: 'Pass',
+            End: true,
+          },
+        },
+      },
+      alarms: {
+        topics: {
+          ok: '${self:service}-${opt:stage}-alerts-ok',
+          alarm: '${self:service}-${opt:stage}-alerts-alarm',
+          insufficientData: '${self:service}-${opt:stage}-alerts-missing',
+        },
+        nameTemplate: '$[stateMachineName]-$[cloudWatchMetricName]-alarm',
+        metrics: [
+          {
+            metric: 'executionsTimedOut',
+            alarmName: 'mycustom-name',
+          },
+          'executionsFailed',
+          'executionsAborted',
+          'executionThrottled',
+          'executionsSucceeded',
+        ],
+      },
+    });
+
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine: genStateMachine('stateCustomName1'),
+      },
+    };
+
+    serverlessStepFunctions.compileAlarms();
+    const resources = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources;
+
+    expect(resources.StateCustomName1ExecutionsTimedOutAlarm.Properties.AlarmName).to.be.equal('mycustom-name');
+    validateCloudWatchAlarm(resources.StateCustomName1ExecutionsTimedOutAlarm);
+    expect(resources.StateCustomName1ExecutionsFailedAlarm.Properties.AlarmName).to.be.equal('stateCustomName1-ExecutionsFailed-alarm');
+    validateCloudWatchAlarm(resources.StateCustomName1ExecutionsFailedAlarm);
+    expect(resources.StateCustomName1ExecutionsAbortedAlarm.Properties.AlarmName).to.be.equal('stateCustomName1-ExecutionsAborted-alarm');
+    validateCloudWatchAlarm(resources.StateCustomName1ExecutionsAbortedAlarm);
+    expect(resources.StateCustomName1ExecutionThrottledAlarm.Properties.AlarmName).to.be.equal('stateCustomName1-ExecutionThrottled-alarm');
+    validateCloudWatchAlarm(resources.StateCustomName1ExecutionThrottledAlarm);
+    expect(consoleLogSpy.callCount).equal(0);
+  });
 });


### PR DESCRIPTION
#### Description

This PR adds support for custom alarm names, currently, all alarms created enabled by the serverless step functions plugins do not set the CloudFormation property `AlarmName`.

This PR enables 2 ways to change the alarm name.

- name template
- per-metric alarm name

#### Name template

```yaml
service: myservice

plugins:
  - serverless-step-functions

stepFunctions:
  stateMachines:
    main-workflow:
      name: main
      alarms:
        nameTemplate: $[stateMachineName]-$[cloudWatchMetricName]-alarm
        topics:
          alarm: !Ref AwsAlertsGenericAlarmTopicAlarm
        metrics:
          - executionsFailed
          - executionsAborted
          - executionsTimedOut
          - executionThrottled
        treatMissingData: ignore
      definition: ${file(./step-functions/main.asl.yaml)}
```

With the `nameTemplate` property the user has the flexibility to change the alarm name, based on this plugin: https://github.com/ACloudGuru/serverless-plugin-aws-alerts.

Suggestion for supported variables to the `nameTemplate`

- `stateMachineName`
- `metricName`
- `cloudWatchMetricName`

#### Per-Metric Alarm Name

```yaml
service: myservice

plugins:
  - serverless-step-functions

stepFunctions:
  stateMachines:
    main-workflow:
      name: main
      alarms:
        nameTemplate: $[stateMachineName]-$[cloudWatchMetricName]-alarm
        topics:
          alarm: !Ref AwsAlertsGenericAlarmTopicAlarm
        metrics:
          - metric: executionsFailed
            alarmName: mycustom-name-${self:stage.region}-Failed-alarm
          - executionsAborted
          - executionsTimedOut
          - executionThrottled
        treatMissingData: ignore
      definition: ${file(./step-functions/main.asl.yaml)}
```

#### Issues

- #494 