### PR TITLE
feat: add support for having a task be based on an object in S3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Publish to NPM
+
+env:
+  package: serverless-step-functions
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.release.target_commitish }}
+    - name: Use Node.js 14
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14
+        registry-url: https://registry.npmjs.org/
+    - run: echo "VERSION=${{ github.event.release.tag_name }}" 
+    - run: npm ci
+    - run: git config --global user.name "Automated NPM Release"
+    - run: git config --global user.email "sysadmin+npm-deploy@aligent.com.au"
+    - run: npm version $VERSION --allow-same-version --workspace "@aligent/${package}"
+    - run: npm run build --workspace "@aligent/${package}"
+    - run: npm test --workspace "@aligent/${package}" --if-present
+    - run: npm publish --access public --workspace "@aligent/${package}"
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - run: git push
+      env:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -372,6 +372,15 @@ function getEventBridgePermissions(state) {
   ];
 }
 
+function getS3GetObjectPermissions(state) {
+  return [{
+    action: 's3:GetObject',
+    resource: [
+      `arn:aws:s3:::${state.Parameters.Bucket}/${state.Parameters.Key}`,
+    ],
+  }];
+}
+
 // if there are multiple permissions with the same action, then collapsed them into one
 // permission instead, and collect the resources into an array
 function consolidatePermissionsByAction(permissions) {
@@ -469,6 +478,9 @@ function getIamPermissions(taskStates) {
       case 'arn:aws:states:::events:putEvents':
       case 'arn:aws:states:::events:putEvents.waitForTaskToken':
         return getEventBridgePermissions(state);
+
+      case 'arn:aws:states:::aws-sdk:s3:getObject':
+        return getS3GetObjectPermissions(state);
 
       default:
         if (isIntrinsic(state.Resource) || !!state.Resource.match(/arn:aws(-[a-z]+)*:lambda/)) {

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -1046,6 +1046,47 @@ describe('#compileIamRole', () => {
     expectDenyAllPolicy(policy);
   });
 
+  it('should give s3:GetObject permission for only objects referenced by state machine', () => {
+    const hello = 'hello.txt';
+    const world = 'world.txt';
+    const testBucket = 'test-bucket';
+
+    const genStateMachine = (id, bucket, key) => ({
+      id,
+      definition: {
+        StartAt: 'A',
+        States: {
+          A: {
+            Type: 'Task',
+            Resource: 'arn:aws:states:::aws-sdk:s3:getObject',
+            Parameters: {
+              Bucket: bucket,
+              Key: key,
+            },
+            End: true,
+          },
+        },
+      },
+    });
+
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: genStateMachine('StateMachine1', testBucket, hello),
+        myStateMachine2: genStateMachine('StateMachine2', testBucket, world),
+      },
+    };
+
+    serverlessStepFunctions.compileIamRole();
+    const resources = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources;
+    const policy1 = resources.StateMachine1Role.Properties.Policies[0];
+    const policy2 = resources.StateMachine2Role.Properties.Policies[0];
+    expect(policy1.PolicyDocument.Statement[0].Resource)
+      .to.be.deep.equal([`arn:aws:s3:::${testBucket}/${hello}`]);
+    expect(policy2.PolicyDocument.Statement[0].Resource)
+      .to.be.deep.equal([`arn:aws:s3:::${testBucket}/${world}`]);
+  });
+
   it('should not generate any permissions for Task states not yet supported', () => {
     const genStateMachine = id => ({
       id,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "serverless-step-functions",
+  "name": "@aligent/serverless-step-functions",
   "version": "3.6.0",
   "description": "The module is AWS Step Functions plugin for Serverless Framework",
   "main": "lib/index.js",


### PR DESCRIPTION
Creates the IAM Role for tasks which are to fetch an object and return it's content, for example:

```yaml
FetchExecutionConfiguration:
    Type: Task
    Resource: arn:aws:states:::aws-sdk:s3:getObject
    Next: DoSomeThingWithConfiguration
    Parameters:
    Bucket: "my-execution-configs"
    Key: "config.json"
```

Currently a task defined this way will result in the following error.

> Cannot generate IAM policy statement for Task state

With this change it correctly deploys and runs, with only the minimum permission granted (i.e. `s3:GetObject` on the specified file).

See:
[Supported AWS SDK service integrations](https://docs.aws.amazon.com/step-functions/latest/dg/supported-services-awssdk.html#supported-services-awssdk-list)