### PR TITLE
fix: Make it work with serverless-import-config-plugin

### DIFF
--- a/lib/yamlParser.js
+++ b/lib/yamlParser.js
@@ -4,18 +4,13 @@ const _ = require('lodash');
 
 module.exports = {
   yamlParse() {
-    const parsedObject = this.serverless.configurationInput;
-
     this.serverless.service.stepFunctions = {
-      validate: parsedObject.stepFunctions ? parsedObject.stepFunctions.validate : false,
-      noOutput: parsedObject.stepFunctions ? parsedObject.stepFunctions.noOutput : false,
+      validate: false,
+      noOutput: false,
+      stateMachines: {},
+      activities: [],
+      ...this.serverless.service.stepFunctions,
     };
-    this.serverless.service.stepFunctions.stateMachines = parsedObject.stepFunctions
-      && parsedObject.stepFunctions.stateMachines
-      ? parsedObject.stepFunctions.stateMachines : {};
-    this.serverless.service.stepFunctions.activities = parsedObject.stepFunctions
-      && parsedObject.stepFunctions.activities
-      ? parsedObject.stepFunctions.activities : [];
 
     if (!this.serverless.pluginManager.cliOptions.stage) {
       this.serverless.pluginManager.cliOptions.stage = this.options.stage


### PR DESCRIPTION
We use serverless-import-config-plugin, but this plugin will only use config in the main serverless.yml entry file.

This PR fixes that and sets the defaults in a simpler way