### PR TITLE
fix(permissionsBoundary): apply permissionsBoundary

### DIFF
--- a/lib/deploy/events/schedule/compileScheduledEvents.js
+++ b/lib/deploy/events/schedule/compileScheduledEvents.js
@@ -5,6 +5,8 @@ const BbPromise = require('bluebird');
 
 module.exports = {
   compileScheduledEvents() {
+    const service = this.serverless.service;
+    const permissionsBoundary = service.provider.rolePermissionsBoundary;
     _.forEach(this.getAllStateMachines(), (stateMachineName) => {
       const stateMachineObj = this.getStateMachine(stateMachineName);
       let scheduleNumberInFunction = 0;
@@ -131,7 +133,7 @@ module.exports = {
               }
             `;
 
-            const iamRoleTemplate = `
+            let iamRoleTemplate = `
             {
               "Type": "AWS::IAM::Role",
               "Properties": {
@@ -169,6 +171,11 @@ module.exports = {
               }
             }
             `;
+            if (permissionsBoundary) {
+              const jsonIamRole = JSON.parse(iamRoleTemplate);
+              jsonIamRole.Properties.PermissionsBoundary = permissionsBoundary;
+              iamRoleTemplate = JSON.stringify(jsonIamRole);
+            }
 
             const newScheduleObject = {
               [scheduleLogicalId]: JSON.parse(scheduleTemplate),

--- a/lib/deploy/events/schedule/compileScheduledEvents.test.js
+++ b/lib/deploy/events/schedule/compileScheduledEvents.test.js
@@ -423,4 +423,28 @@ describe('#httpValidate()', () => {
       expect(() => serverlessStepFunctions.compileScheduledEvents()).to.throw(Error);
     });
   });
+  it('should handle permissionsBoundary', () => {
+    serverlessStepFunctions.serverless.service.stepFunctions = {
+      stateMachines: {
+        first: {
+          events: [
+            {
+              schedule: {
+                rate: 'rate(10 minutes)',
+                enabled: false,
+                inputPath: '$.stageVariables',
+              },
+            },
+          ],
+        },
+      },
+    };
+    serverless.service.provider.rolePermissionsBoundary = 'arn:aws:iam::myAccount:policy/permission_boundary';
+    serverlessStepFunctions.compileScheduledEvents();
+
+    expect(serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources
+      .FirstScheduleToStepFunctionsRole
+      .Properties.PermissionsBoundary).to.equal('arn:aws:iam::myAccount:policy/permission_boundary');
+  });
 });

--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -563,6 +563,8 @@ function getIamStatements(iamPermissions, stateMachineObj) {
 module.exports = {
   compileIamRole() {
     logger.config(this.serverless, this.v3Api);
+    const service = this.serverless.service;
+    const permissionsBoundary = service.provider.rolePermissionsBoundary;
     this.getAllStateMachines().forEach((stateMachineName) => {
       const stateMachineObj = this.getStateMachine(stateMachineName);
       if (stateMachineObj.role) {
@@ -601,9 +603,15 @@ module.exports = {
           'iam-role-statemachine-execution-template.txt'),
       );
 
-      const iamRoleJson = iamRoleStateMachineExecutionTemplate
+      let iamRoleJson = iamRoleStateMachineExecutionTemplate
         .replace('[PolicyName]', this.getStateMachinePolicyName())
         .replace('[Statements]', JSON.stringify(iamStatements));
+
+      if (permissionsBoundary) {
+        const jsonIamRole = JSON.parse(iamRoleJson);
+        jsonIamRole.Properties.PermissionsBoundary = permissionsBoundary;
+        iamRoleJson = JSON.stringify(jsonIamRole);
+      }
 
       const stateMachineLogicalId = this.getStateMachineLogicalId(
         stateMachineName,

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -2647,4 +2647,30 @@ describe('#compileIamRole', () => {
       },
     ]);
   });
+  it('should handle permissionsBoundary', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          id: 'StateMachine1',
+          definition: {
+            StartAt: 'A',
+            States: {
+              A: {
+                Type: 'Task',
+                Resource:
+                  'arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:hello',
+                End: true,
+              },
+            },
+          },
+        },
+      },
+    };
+    serverless.service.provider.rolePermissionsBoundary = 'arn:aws:iam::myAccount:policy/permission_boundary';
+    serverlessStepFunctions.compileIamRole();
+    const boundary = serverlessStepFunctions.serverless.service.provider
+      .compiledCloudFormationTemplate.Resources.StateMachine1Role.Properties
+      .PermissionsBoundary;
+    expect(boundary).to.equal('arn:aws:iam::myAccount:policy/permission_boundary');
+  });
 });

--- a/lib/deploy/stepFunctions/compileNotifications.test.js
+++ b/lib/deploy/stepFunctions/compileNotifications.test.js
@@ -522,31 +522,4 @@ describe('#compileNotifications', () => {
     expect(logMessage.startsWith('State machine [Beta1] : notifications are not supported on Express Workflows.'))
       .to.equal(true);
   });
-
-  it('should handle permissionsBoundary', () => {
-    serverless.service.stepFunctions = {
-      stateMachines: {
-        myStateMachine1: {
-          id: 'StateMachine1',
-          definition: {
-            StartAt: 'A',
-            States: {
-              A: {
-                Type: 'Task',
-                Resource:
-                  'arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:hello',
-                End: true,
-              },
-            },
-          },
-        },
-      },
-    };
-    serverless.service.provider.rolePermissionsBoundary = 'arn:aws:iam::myAccount:policy/permission_boundary';
-    serverlessStepFunctions.compileIamRole();
-    const boundary = serverlessStepFunctions.serverless.service.provider
-      .compiledCloudFormationTemplate.Resources.StateMachine1Role.Properties
-      .PermissionsBoundary;
-    expect(boundary).to.equal('arn:aws:iam::myAccount:policy/permission_boundary');
-  });
 });

--- a/lib/deploy/stepFunctions/compileNotifications.test.js
+++ b/lib/deploy/stepFunctions/compileNotifications.test.js
@@ -522,4 +522,31 @@ describe('#compileNotifications', () => {
     expect(logMessage.startsWith('State machine [Beta1] : notifications are not supported on Express Workflows.'))
       .to.equal(true);
   });
+
+  it('should handle permissionsBoundary', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          id: 'StateMachine1',
+          definition: {
+            StartAt: 'A',
+            States: {
+              A: {
+                Type: 'Task',
+                Resource:
+                  'arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:hello',
+                End: true,
+              },
+            },
+          },
+        },
+      },
+    };
+    serverless.service.provider.rolePermissionsBoundary = 'arn:aws:iam::myAccount:policy/permission_boundary';
+    serverlessStepFunctions.compileIamRole();
+    const boundary = serverlessStepFunctions.serverless.service.provider
+      .compiledCloudFormationTemplate.Resources.StateMachine1Role.Properties
+      .PermissionsBoundary;
+    expect(boundary).to.equal('arn:aws:iam::myAccount:policy/permission_boundary');
+  });
 });


### PR DESCRIPTION
This PR allows using a Permissions Boundary defined in the provider level e.g. 

``` yaml
provider:
  name: aws
  runtime: python3.9
  # the permisions boundary goes here 
  rolePermissionsBoundary: arn:aws:iam::[account]:policy/permission_boundary  
  # ...
```

Previously, the boundary was only applied to the created lambda execution role, but was missing on the created roles for functions of the state machine as described in [issue 395](https://github.com/serverless-operations/serverless-step-functions/issues/395) some time ago. 

We run into the same issue yesterday well using the newest version of serverless and this plugin. The submitted fix worked for us. 
 