### PR TITLE
feat: support the latest SFN ItemProcessor (replaces Iterator)

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -19,7 +19,7 @@ function getTaskStates(states) {
         return getTaskStates(parallelStates);
       }
       case 'Map': {
-        const mapStates = state.Iterator.States;
+        const mapStates = state.ItemProcessor ? state.ItemProcessor.States : state.Iterator.States;
         return getTaskStates(mapStates);
       }
       default: {

--- a/lib/deploy/stepFunctions/compileStateMachines.test.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.test.js
@@ -1647,4 +1647,85 @@ describe('#compileStateMachines', () => {
     // Definition is invalid and validate=true, should throw
     expect(() => serverlessStepFunctions.compileStateMachines()).to.throw(Error);
   });
+
+  it('should compile with the old Iterator', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          id: 'Test',
+          name: 'test',
+          definition: {
+            StartAt: 'One',
+            States: {
+              One: {
+                Type: 'Map',
+                Iterator: {
+                  StartAt: 'Two',
+                  States: {
+                    Two: {
+                      Type: 'Wait',
+                      Seconds: 10,
+                      End: true,
+                    },
+                  },
+                },
+                End: true,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    serverlessStepFunctions.compileStateMachines();
+    const stateMachine = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources
+      .Test;
+
+    expect(stateMachine.Properties.DefinitionString).to.not.haveOwnProperty('Fn::Sub');
+    const stateMachineObj = JSON.parse(stateMachine.Properties.DefinitionString);
+    expect(stateMachineObj.States).to.haveOwnProperty('One');
+  });
+
+  it('should compile with the new ItemProcessor', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          id: 'Test',
+          name: 'test',
+          definition: {
+            StartAt: 'One',
+            States: {
+              One: {
+                Type: 'Map',
+                ItemProcessor: {
+                  ProcessorConfig: {
+                    Mode: 'INLINE',
+                  },
+                  StartAt: 'Two',
+                  States: {
+                    Two: {
+                      Type: 'Wait',
+                      Seconds: 10,
+                      End: true,
+                    },
+                  },
+                },
+                End: true,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    serverlessStepFunctions.compileStateMachines();
+    const stateMachine = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources
+      .Test;
+
+    expect(stateMachine.Properties.DefinitionString).to.not.haveOwnProperty('Fn::Sub');
+    const stateMachineObj = JSON.parse(stateMachine.Properties.DefinitionString);
+    expect(stateMachineObj.States).to.haveOwnProperty('One');
+  });
 });


### PR DESCRIPTION
When building a new step function I noticed that what was previously the `Iterator` has been changed to `ItemProcessor`. Probably changed with reinvent and their release of Distributed Maps. Here's an example of a state machine that I built with their visual builder and then adjusted to reference my functions: https://github.com/bahrmichael/trade-game-backend/pull/50/commits/9a75d378d7e67673bffc448f5507793c2eb9408e#diff-ea2dbe8c0992878214f1020b0c7ee79668dc63b5c8325a5ed67892d0080a9b27

When setting `validate: true` I noticed that the plugin expects an `Iterator` within a `Map` task, which fails with the new `ItemProcessor`: https://github.com/bahrmichael/trade-game-backend/actions/runs/3633513042/jobs/6130610217

This PR shows how far I've gotten, but there seems to be another error where I'm not sure if merging this PR already would cause problems for other folks: https://github.com/bahrmichael/trade-game-backend/actions/runs/3633603701/jobs/6130803277

Let me know what you think! I'm not confident that the test is sufficient, please give me a pointer on what it should also test.