### PR TITLE
feat: generate permission for dynamodb:Query and for GSIs

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -130,6 +130,67 @@ function getDynamoDBArn(tableName) {
   };
 }
 
+function getDynamoDBIndexArn(tableName, indexName) {
+  if (isIntrinsic(tableName)) {
+    // most likely we'll see a { Ref: LogicalId }, which we need to map to
+    // { Fn::GetAtt: [ LogicalId, Arn ] } to get the ARN
+    if (tableName.Ref) {
+      return {
+        'Fn::Join': [
+          '/',
+          [
+            { 'Fn::GetAtt': [tableName.Ref, 'Arn'] },
+            'index',
+            indexName,
+          ],
+        ],
+      };
+    }
+    // but also support importing the table name from an external stack that exports it
+    // as we still want to support direct state machine actions interacting with those tables
+    if (tableName['Fn::ImportValue']) {
+      return {
+        'Fn::Join': [
+          ':',
+          [
+            'arn',
+            { Ref: 'AWS::Partition' },
+            'dynamodb',
+            { Ref: 'AWS::Region' },
+            { Ref: 'AWS::AccountId' },
+            {
+              'Fn::Join': [
+                '/',
+                [
+                  'table',
+                  tableName,
+                  'index',
+                  indexName,
+                ],
+              ],
+            },
+          ],
+        ],
+      };
+    }
+  }
+
+  return {
+    'Fn::Join': [
+      ':',
+      [
+        'arn',
+        { Ref: 'AWS::Partition' },
+        'dynamodb',
+        { Ref: 'AWS::Region' },
+        { Ref: 'AWS::AccountId' },
+        `table/${tableName}/index/${indexName}`,
+      ],
+    ],
+  };
+}
+
+
 function getBatchPermissions() {
   return [{
     action: 'batch:SubmitJob,batch:DescribeJobs,batch:TerminateJob',
@@ -182,19 +243,19 @@ function getEcsPermissions() {
 }
 
 function getDynamoDBPermissions(action, state) {
-  const tableArn = state.Parameters['TableName.$']
-    ? '*'
-    : getDynamoDBArn(state.Parameters.TableName);
-
   const indexName = state.Parameters['IndexName.$']
     ? '*'
     : state.Parameters.IndexName;
 
   let resource;
   if (indexName) {
-    resource = `${tableArn}/index/${indexName}`;
+    resource = state.Parameters['TableName.$']
+      ? '*'
+      : getDynamoDBIndexArn(state.Parameters.TableName, indexName);
   } else {
-    resource = tableArn;
+    resource = state.Parameters['TableName.$']
+      ? '*'
+      : getDynamoDBArn(state.Parameters.TableName);
   }
   return [{
     action,

--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -130,67 +130,6 @@ function getDynamoDBArn(tableName) {
   };
 }
 
-function getDynamoDBIndexArn(tableName, indexName) {
-  if (isIntrinsic(tableName)) {
-    // most likely we'll see a { Ref: LogicalId }, which we need to map to
-    // { Fn::GetAtt: [ LogicalId, Arn ] } to get the ARN
-    if (tableName.Ref) {
-      return {
-        'Fn::Join': [
-          '/',
-          [
-            { 'Fn::GetAtt': [tableName.Ref, 'Arn'] },
-            'index',
-            indexName,
-          ],
-        ],
-      };
-    }
-    // but also support importing the table name from an external stack that exports it
-    // as we still want to support direct state machine actions interacting with those tables
-    if (tableName['Fn::ImportValue']) {
-      return {
-        'Fn::Join': [
-          ':',
-          [
-            'arn',
-            { Ref: 'AWS::Partition' },
-            'dynamodb',
-            { Ref: 'AWS::Region' },
-            { Ref: 'AWS::AccountId' },
-            {
-              'Fn::Join': [
-                '/',
-                [
-                  'table',
-                  tableName,
-                  'index',
-                  indexName,
-                ],
-              ],
-            },
-          ],
-        ],
-      };
-    }
-  }
-
-  return {
-    'Fn::Join': [
-      ':',
-      [
-        'arn',
-        { Ref: 'AWS::Partition' },
-        'dynamodb',
-        { Ref: 'AWS::Region' },
-        { Ref: 'AWS::AccountId' },
-        `table/${tableName}/index/${indexName}`,
-      ],
-    ],
-  };
-}
-
-
 function getBatchPermissions() {
   return [{
     action: 'batch:SubmitJob,batch:DescribeJobs,batch:TerminateJob',
@@ -243,26 +182,31 @@ function getEcsPermissions() {
 }
 
 function getDynamoDBPermissions(action, state) {
-  const indexName = state.Parameters['IndexName.$']
-    ? '*'
-    : state.Parameters.IndexName;
-
   let resource;
-  if (indexName) {
-    resource = state.Parameters['TableName.$']
+
+  if (state.Parameters['TableName.$']) {
+    // When the TableName is only known at runtime, we
+    // have to provide * permissions during deployment.
+    resource = '*';
+  } else if (state.Parameters['IndexName.$'] || state.Parameters.IndexName) {
+    // When the Parameters contain an IndexName, we have to build a
+    // longer arn that includes the index.
+    const indexName = state.Parameters['IndexName.$']
+      // We must provide * here instead of state.Parameters['IndexName.$'], because we don't know
+      // which index will be targeted when we the step function runs
       ? '*'
-      : getDynamoDBIndexArn(state.Parameters.TableName, indexName);
+      : state.Parameters.IndexName;
+
+    resource = getDynamoDBArn(`${state.Parameters.TableName}/index/${indexName}`);
   } else {
-    resource = state.Parameters['TableName.$']
-      ? '*'
-      : getDynamoDBArn(state.Parameters.TableName);
+    resource = getDynamoDBArn(state.Parameters.TableName);
   }
+
   return [{
     action,
     resource,
   }];
 }
-
 function getRedshiftDataPermissions(action, state) {
   if (['redshift-data:ExecuteStatement', 'redshift-data:BatchExecuteStatement'].includes(action)) {
     const clusterName = _.has(state, 'Parameters.ClusterIdentifier') ? state.Parameters.ClusterIdentifier : '*';

--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -186,9 +186,19 @@ function getDynamoDBPermissions(action, state) {
     ? '*'
     : getDynamoDBArn(state.Parameters.TableName);
 
+  const indexName = state.Parameters['IndexName.$']
+    ? '*'
+    : state.Parameters.IndexName;
+
+  let resource;
+  if (indexName) {
+    resource = `${tableArn}/index/${indexName}`;
+  } else {
+    resource = tableArn;
+  }
   return [{
     action,
-    resource: tableArn,
+    resource,
   }];
 }
 
@@ -466,6 +476,8 @@ function getIamPermissions(taskStates) {
         return getDynamoDBPermissions('dynamodb:DeleteItem', state);
       case 'arn:aws:states:::aws-sdk:dynamodb:updateTable':
         return getDynamoDBPermissions('dynamodb:UpdateTable', state);
+      case 'arn:aws:states:::aws-sdk:dynamodb:query':
+        return getDynamoDBPermissions('dynamodb:Query', state);
 
       case 'arn:aws:states:::aws-sdk:redshiftdata:executeStatement':
         return getRedshiftDataPermissions('redshift-data:ExecuteStatement', state);

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -731,6 +731,58 @@ describe('#compileIamRole', () => {
       .to.be.deep.equal([worldTableArn]);
   });
 
+  it('should give dynamodb permission to index table whenever IndexName is provided', () => {
+    const helloTable = 'hello';
+
+    const genStateMachine = (id, tableName) => ({
+      id,
+      definition: {
+        StartAt: 'A',
+        States: {
+          A: {
+            Type: 'Task',
+            Resource: 'arn:aws:states:::aws-sdk:dynamodb:query',
+            Parameters: {
+              TableName: tableName,
+            },
+            Next: 'B',
+          },
+          B: {
+            Type: 'Task',
+            Resource: 'arn:aws:states:::aws-sdk:dynamodb:query',
+            Parameters: {
+              TableName: tableName,
+              IndexName: 'GSI1',
+            },
+            End: true,
+          },
+        },
+      },
+    });
+
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: genStateMachine('StateMachine1', helloTable),
+      },
+    };
+
+    serverlessStepFunctions.compileIamRole();
+    const policy = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources.StateMachine1Role
+      .Properties.Policies[0];
+
+    expect(policy.PolicyDocument.Statement[0].Action)
+      .to.be.deep.equal(['dynamodb:Query']);
+
+    expect(policy.PolicyDocument.Statement[0].Resource[0]).to.be.deep.equal({
+      'Fn::Join': [':', ['arn', { Ref: 'AWS::Partition' }, 'dynamodb', { Ref: 'AWS::Region' }, { Ref: 'AWS::AccountId' }, 'table/hello']],
+    });
+
+    expect(policy.PolicyDocument.Statement[0].Resource[1]).to.be.deep.equal({
+      'Fn::Join': [':', ['arn', { Ref: 'AWS::Partition' }, 'dynamodb', { Ref: 'AWS::Region' }, { Ref: 'AWS::AccountId' }, 'table/hello/index/GSI1']],
+    });
+  });
+
   it('should give dynamodb permission to * whenever TableName.$ is seen', () => {
     const helloTable = 'hello';
 
@@ -776,6 +828,84 @@ describe('#compileIamRole', () => {
     // have to give broad permissions to allow execution to talk to whatever table
     // the input specifies
     expect(policy.PolicyDocument.Statement[0].Resource).to.equal('*');
+  });
+
+  it('should give dynamodb permission to table/TableName/index/* when IndexName.$ is seen', () => {
+    const helloTable = 'hello';
+
+    const genStateMachine = (id, tableName) => ({
+      id,
+      definition: {
+        StartAt: 'A',
+        States: {
+          A: {
+            Type: 'Task',
+            Resource: 'arn:aws:states:::aws-sdk:dynamodb:query',
+            Parameters: {
+              TableName: tableName,
+              'IndexName.$': '$.myDynamicIndexName',
+            },
+            End: true,
+          },
+        },
+      },
+    });
+
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: genStateMachine('StateMachine1', helloTable),
+      },
+    };
+
+    serverlessStepFunctions.compileIamRole();
+    const policy = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources.StateMachine1Role
+      .Properties.Policies[0];
+    expect(policy.PolicyDocument.Statement[0].Action)
+      .to.be.deep.equal(['dynamodb:Query']);
+
+    // even though some tasks target specific indices, because IndexName.$ is used we
+    // have to give broad permissions to allow execution to talk to whatever index
+    // the input specifies
+    expect(policy.PolicyDocument.Statement[0].Resource[0]['Fn::Join'][1][5]).to.equal('table/hello/index/*');
+  });
+
+  it('should give dynamodb permission to table/* whenever TableName.$ and IndexName.$ are seen', () => {
+    const genStateMachine = id => ({
+      id,
+      definition: {
+        StartAt: 'A',
+        States: {
+          A: {
+            Type: 'Task',
+            Resource: 'arn:aws:states:::aws-sdk:dynamodb:query',
+            Parameters: {
+              'TableName.$': '$.myDynamicTableName',
+              'IndexName.$': '$.myDynamicIndexName',
+            },
+            End: true,
+          },
+        },
+      },
+    });
+
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: genStateMachine('StateMachine1'),
+      },
+    };
+
+    serverlessStepFunctions.compileIamRole();
+    const policy = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources.StateMachine1Role
+      .Properties.Policies[0];
+    expect(policy.PolicyDocument.Statement[0].Action)
+      .to.be.deep.equal(['dynamodb:Query']);
+
+    // even though some tasks target specific tables, because TableName.$ is used we
+    // have to give broad permissions to allow execution to talk to whatever table
+    // the input specifies
+    expect(policy.PolicyDocument.Statement[0].Resource[0]).to.equal('*');
   });
 
   it('should give Redshift Data permissions to * for safe actions', () => {


### PR DESCRIPTION
This PR adds support to generate IAM statements for `dynamodb:Query`.

Currently I get this error:

```
Cannot generate IAM policy statement for Task state { Type: 'Task',
  Parameters:
   { TableName: { Ref: 'OrdersTable' },
     IndexName: 'GSI1',
     KeyConditionExpression: 'gsi1 = :k',
     FilterExpression: '$.listMatchableOrdersFilter',
     ExpressionAttributeValues: { ':k': { 'S.$': '$.listMatchableOrdersKey' }, ':p': { 'N.$': '$.newOrder.pricePerUnit' } } },
  Resource: 'arn:aws:states:::aws-sdk:dynamodb:query',
  Next: 'Is Empty?',
  ResultPath: '$.matchableOrders' }
```

With this PR it should be able to generate a statement that supports the Query operation, and also supports GSIs. I went with a wildcard `*` index following the table related code above. If the index name is only known at runtime, there's no way we can grant any correct permission that's not a `*` index.

If the `Parameters` contain neither `IndexName.$` nor `IndexName`, then the changed code will return the table name as before this PR.