### PR TITLE
Adding support for Map in Distributed Mode

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -19,8 +19,13 @@ function getTaskStates(states) {
         return getTaskStates(parallelStates);
       }
       case 'Map': {
-        const mapStates = state.Iterator.States;
-        return getTaskStates(mapStates);
+        if (Object.hasOwn(state, 'Iterator')) {
+          return getTaskStates(state.Iterator.States);
+        }
+        if (Object.hasOwn(state, 'ItemProcessor')) {
+          return getTaskStates(state.ItemProcessor.States);
+        }
+        return [];
       }
       default: {
         return [];

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -2232,6 +2232,55 @@ describe('#compileIamRole', () => {
     expect(lambdaPermissions[0].Resource).to.deep.equal(lambdaArns);
   });
 
+  it('should support Map state type with ItemProcessor', () => {
+    const getStateMachine = (id, lambdaArn) => ({
+      id,
+      definition: {
+        StartAt: 'A',
+        States: {
+          A: {
+            Type: 'Map',
+            ItemProcessor: {
+              ProcessorConfig: {
+                Mode: 'DISTRIBUTED',
+                ExecutionType: 'EXPRESS',
+              },
+              StartAt: 'B',
+              States: {
+                B: {
+                  Type: 'Task',
+                  Resource: lambdaArn,
+                  End: true,
+                },
+              },
+            },
+            End: true,
+          },
+        },
+      },
+    });
+
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine: getStateMachine('StateMachine1', 'arn:aws:lambda:us-west-2:1234567890:function:foo'),
+      },
+    };
+
+    serverlessStepFunctions.compileIamRole();
+    const statements = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources.StateMachine1Role
+      .Properties.Policies[0].PolicyDocument.Statement;
+
+    const lambdaPermissions = statements.filter(s => _.isEqual(s.Action, ['lambda:InvokeFunction']));
+    expect(lambdaPermissions).to.have.lengthOf(1);
+
+    const lambdaArns = [
+      'arn:aws:lambda:us-west-2:1234567890:function:foo',
+      getAlias('arn:aws:lambda:us-west-2:1234567890:function:foo'),
+    ];
+    expect(lambdaPermissions[0].Resource).to.deep.equal(lambdaArns);
+  });
+
   it('should support nested Map state type', () => {
     const getStateMachine = (id, lambdaArn1, lambdaArn2) => ({
       id,


### PR DESCRIPTION
AWS released a new feature for Map called Distributed Mode, which allows for distributed processing in a Map. The IAM role compilation needs to be tweaked to handle this new format, otherwise it deploys fine.

Note: this does not currently work with `validate: true` as [asl-validator](https://github.com/ChristopheBougere/asl-validator) does not yet support this behavior.