### PR TITLE
feat: generate IAM policy for S3 when ItemReader is used

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -20,7 +20,11 @@ function getTaskStates(states) {
       }
       case 'Map': {
         const mapStates = state.ItemProcessor ? state.ItemProcessor.States : state.Iterator.States;
-        return getTaskStates(mapStates);
+        const taskStates = getTaskStates(mapStates);
+        if (state.ItemReader) {
+          taskStates.push(state.ItemReader);
+        }
+        return taskStates;
       }
       default: {
         return [];
@@ -395,10 +399,21 @@ function getEventBridgePermissions(state) {
 }
 
 function getS3GetObjectPermissions(state) {
+  const bucket = state.Parameters['Bucket.$'] ? state.Parameters['Bucket.$'] : state.Parameters.Bucket;
+  const key = state.Parameters['Key.$'] ? state.Parameters['Key.$'] : state.Parameters.Key;
+
+  if (bucket.startsWith('$') && key.startsWith('$')) {
+    return [{
+      action: 's3:GetObject',
+      resource: [
+        '*',
+      ],
+    }];
+  }
   return [{
     action: 's3:GetObject',
     resource: [
-      `arn:aws:s3:::${state.Parameters.Bucket}/${state.Parameters.Key}`,
+      `arn:aws:s3:::${bucket}/${key}`,
     ],
   }];
 }
@@ -514,6 +529,7 @@ function getIamPermissions(taskStates) {
       case 'arn:aws:states:::events:putEvents.waitForTaskToken':
         return getEventBridgePermissions(state);
 
+      case 'arn:aws:states:::s3:getObject':
       case 'arn:aws:states:::aws-sdk:s3:getObject':
         return getS3GetObjectPermissions(state);
 

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -1363,6 +1363,60 @@ describe('#compileIamRole', () => {
       .to.be.deep.equal([`arn:aws:s3:::${testBucket}/${world}`]);
   });
 
+  it('should give s3:GetObject permission for only objects referenced by state machine with ItemReader', () => {
+    const testBucket = 'test-bucket';
+    const testKey = 'test-key';
+
+    const genStateMachine = (id, lambdaArn, bucket, key) => ({
+      id,
+      definition: {
+        StartAt: 'A',
+        States: {
+          A: {
+            Type: 'Map',
+            ItemProcessor: {
+              StartAt: 'B',
+              States: {
+                B: {
+                  Type: 'Task',
+                  Resource: lambdaArn,
+                  End: true,
+                },
+              },
+            },
+            ItemReader: {
+              Resource: 'arn:aws:states:::s3:getObject',
+              Parameters: {
+                'Bucket.$': bucket,
+                'Key.$': key,
+              },
+            },
+            End: true,
+          },
+        },
+      },
+    });
+
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: genStateMachine('StateMachine1',
+          'arn:aws:lambda:us-west-2:1234567890:function:foo', '$.testBucket', '$.testKey'),
+        myStateMachine2: genStateMachine('StateMachine2',
+          'arn:aws:lambda:us-west-2:1234567890:function:foo', testBucket, testKey),
+      },
+    };
+
+    serverlessStepFunctions.compileIamRole();
+    const resources = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources;
+    const policy1 = resources.StateMachine1Role.Properties.Policies[0];
+    const policy2 = resources.StateMachine2Role.Properties.Policies[0];
+    expect(policy1.PolicyDocument.Statement[1].Resource)
+      .to.be.deep.equal('*');
+    expect(policy2.PolicyDocument.Statement[1].Resource)
+      .to.be.deep.equal([`arn:aws:s3:::${testBucket}/${testKey}`]);
+  });
+
   it('should not generate any permissions for Task states not yet supported', () => {
     const genStateMachine = id => ({
       id,


### PR DESCRIPTION
**Issue**: When `ItemReader` is used to download the files from S3, IAM policy is not created to access S3.

**Solution**: Adding an IAM policy with `Resource: *` when the bucket and key are sent dynamically.

 `Resource: *`: [ItemReader AWS Documenation](https://docs.amazonaws.cn/en_us/step-functions/latest/dg/input-output-itemreader.html#itemreader-iam-policiesac)

**Notes**: I cross referenced the policy by  creating step function from AWS UI and the IAM policy generated had `Resource: *` when `bucket` and `key` were passed dynamically.


Please let me know if I need to make any further changes.