### PR TITLE
feat: add IAM role to distributed_map to start the state machine

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -8,7 +8,7 @@ const { getArnPartition } = require('../../utils/arn');
 
 const logger = require('../../utils/logger');
 
-function getTaskStates(states) {
+function getTaskStates(states, stateMachineName) {
   return _.flatMap(states, (state) => {
     switch (state.Type) {
       case 'Task': {
@@ -16,11 +16,19 @@ function getTaskStates(states) {
       }
       case 'Parallel': {
         const parallelStates = _.flatMap(state.Branches, branch => _.values(branch.States));
-        return getTaskStates(parallelStates);
+        return getTaskStates(parallelStates, stateMachineName);
       }
       case 'Map': {
         const mapStates = state.ItemProcessor ? state.ItemProcessor.States : state.Iterator.States;
-        return getTaskStates(mapStates);
+        const taskStates = getTaskStates(mapStates, stateMachineName);
+        if (state.ItemProcessor && state.ItemProcessor.ProcessorConfig.Mode === 'DISTRIBUTED') {
+          taskStates.push({
+            Resource: 'arn:aws:states:::states:startExecution',
+            Mode: 'DISTRIBUTED',
+            StateMachineName: stateMachineName,
+          });
+        }
+        return taskStates;
       }
       default: {
         return [];
@@ -299,9 +307,16 @@ function getLambdaPermissions(state) {
 }
 
 function getStepFunctionsPermissions(state) {
-  const stateMachineArn = state.Parameters['StateMachineArn.$']
-    ? '*'
-    : state.Parameters.StateMachineArn;
+  let stateMachineArn = state.Mode === 'DISTRIBUTED' ? {
+    'Fn::Sub': [
+      `arn:aws:states:\${AWS::Region}:\${AWS::AccountId}:stateMachine:${state.StateMachineName}`,
+    ],
+  } : null;
+
+  if (!stateMachineArn) {
+    stateMachineArn = state.Parameters['StateMachineArn.$'] ? '*'
+      : state.Parameters.StateMachineArn;
+  }
 
   return [{
     action: 'states:StartExecution',
@@ -575,7 +590,7 @@ module.exports = {
         throw new Error(`Missing "definition" for state machine ${stateMachineName}`);
       }
 
-      const taskStates = getTaskStates(stateMachineObj.definition.States);
+      const taskStates = getTaskStates(stateMachineObj.definition.States, stateMachineName);
       let iamPermissions = getIamPermissions.bind(this)(taskStates);
 
       if (stateMachineObj.loggingConfig) {

--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -21,12 +21,14 @@ function getTaskStates(states, stateMachineName) {
       case 'Map': {
         const mapStates = state.ItemProcessor ? state.ItemProcessor.States : state.Iterator.States;
         const taskStates = getTaskStates(mapStates, stateMachineName);
-        if (state.ItemProcessor && state.ItemProcessor.ProcessorConfig.Mode === 'DISTRIBUTED') {
+        if (state.ItemProcessor && state.ItemProcessor.ProcessorConfig
+          && state.ItemProcessor.ProcessorConfig.Mode === 'DISTRIBUTED') {
           taskStates.push({
             Resource: 'arn:aws:states:::states:startExecution',
             Mode: 'DISTRIBUTED',
             StateMachineName: stateMachineName,
           });
+        }
         if (state.ItemReader) {
           taskStates.push(state.ItemReader);
         }

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -2232,6 +2232,63 @@ describe('#compileIamRole', () => {
     expect(lambdaPermissions[0].Resource).to.deep.equal(lambdaArns);
   });
 
+  it('should support Distributed Map state type', () => {
+    const getStateMachine = (id, lambdaArn) => ({
+      id,
+      definition: {
+        StartAt: 'A',
+        States: {
+          A: {
+            Type: 'Map',
+            ItemProcessor: {
+              ProcessorConfig: {
+                Mode: 'DISTRIBUTED',
+              },
+              StartAt: 'B',
+              States: {
+                B: {
+                  Type: 'Task',
+                  Resource: lambdaArn,
+                  End: true,
+                },
+              },
+            },
+            End: true,
+          },
+        },
+      },
+    });
+
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine: getStateMachine('StateMachine1', 'arn:aws:lambda:us-west-2:1234567890:function:foo'),
+      },
+    };
+
+    serverlessStepFunctions.compileIamRole();
+    const statements = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources.StateMachine1Role
+      .Properties.Policies[0].PolicyDocument.Statement;
+
+    const lambdaPermissions = statements.filter(s => _.isEqual(s.Action, ['lambda:InvokeFunction']));
+    expect(lambdaPermissions).to.have.lengthOf(1);
+
+    const lambdaArns = [
+      'arn:aws:lambda:us-west-2:1234567890:function:foo',
+      getAlias('arn:aws:lambda:us-west-2:1234567890:function:foo'),
+    ];
+    expect(lambdaPermissions[0].Resource).to.deep.equal(lambdaArns);
+
+    const stepFunctionPermission = statements.filter(s => _.isEqual(s.Action, ['states:StartExecution']));
+    expect(stepFunctionPermission).to.have.lengthOf(1);
+    expect(stepFunctionPermission[0].Resource).to.deep.eq([{
+      'Fn::Sub': [
+        'arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:myStateMachine',
+      ],
+    },
+    ]);
+  });
+
   it('should support nested Map state type', () => {
     const getStateMachine = (id, lambdaArn1, lambdaArn2) => ({
       id,


### PR DESCRIPTION
**Issue**: When executing a state machine with a [Map state in Distributed mode](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-asl-use-map-state-distributed.html), the execution fails at the Map state because execution role does not have sufficient permissions to run a Distributed Map.

**Solution**: I tired to use the current pass that we do to collect the tasks and generate additional policy which gives access to trigger the `stepFunction`. I couldn't find a better way to access the name of the `stepFunction` so I had to pass it as a parameter.


This should also solve this [issue](https://github.com/serverless-operations/serverless-step-functions/issues/543)


**Notes:**

- With the changes in the PR, I've deployed my stepFunction to AWS and it seems to work alright in distributed mode.
- Please let me know if I can make it better