### PR TITLE
feat: update asl_validator plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hapi/joi": "^15.0.2",
         "@serverless/utils": "^6.7.0",
-        "asl-validator": "^3.0.8",
+        "asl-validator": "^3.1.0",
         "bluebird": "^3.4.0",
         "chalk": "^4.1.2",
         "lodash": "^4.17.11"
@@ -2939,9 +2939,9 @@
       }
     },
     "node_modules/asl-validator": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-3.0.8.tgz",
-      "integrity": "sha512-ku2hkt137ebImA6DNySVoBtymffl/62TQHWKBb54yI3twrcsQyi78fPtvRi+PMob89vLeb0BbGezr5+4rQcJ7Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-3.1.0.tgz",
+      "integrity": "sha512-J2OmT6lkj2RHojDLWyqh33BNCBfpOIAEl1z01cd/4WiGt8Sjgqx+gbX7WsgVKGS4uF/pGwc1EkrZvm0mSRMcWA==",
       "dependencies": {
         "ajv": "^8.11.0",
         "asl-path-validator": "^0.11.0",
@@ -17883,7 +17883,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "6.3.0",
@@ -18151,7 +18152,7 @@
       "requires": {
         "@serverless/core": "^1.1.2",
         "@serverless/template": "^1.1.3",
-        "@serverless/utils": "^6.7.0",
+        "@serverless/utils": "^1.2.0",
         "ansi-escapes": "^4.3.1",
         "chalk": "^2.4.2",
         "chokidar": "^3.4.1",
@@ -18163,7 +18164,8 @@
       },
       "dependencies": {
         "@serverless/utils": {
-          "version": "https://registry.npmjs.org/@serverless/utils/-/utils-1.2.0.tgz",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@serverless/utils/-/utils-1.2.0.tgz",
           "integrity": "sha512-aI/cpGVUhWbJUR8QDMtPue28EU4ViG/L4/XKuZDfAN2uNQv3NRjwEFIBi/cxyfQnMTYVtMLe9wDjuwzOT4ENzA==",
           "dev": true,
           "requires": {
@@ -18274,7 +18276,7 @@
       "requires": {
         "@serverless/platform-client": "^4.2.2",
         "@serverless/platform-client-china": "^2.2.0",
-        "@serverless/utils": "^6.7.0",
+        "@serverless/utils": "^4.0.0",
         "adm-zip": "^0.5.4",
         "ansi-escapes": "^4.3.1",
         "chalk": "^4.1.0",
@@ -18304,7 +18306,8 @@
       },
       "dependencies": {
         "@serverless/utils": {
-          "version": "https://registry.npmjs.org/@serverless/utils/-/utils-4.1.0.tgz",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@serverless/utils/-/utils-4.1.0.tgz",
           "integrity": "sha512-cl5uPaGg72z0sCUpF0zsOhwYYUV72Gxc1FwFfxltO8hSvMeFDvwD7JrNE4kHcIcKRjwPGbSH0fdVPUpErZ8Mog==",
           "dev": true,
           "requires": {
@@ -18510,7 +18513,7 @@
       "requires": {
         "@serverless/event-mocks": "^1.1.1",
         "@serverless/platform-client": "^4.3.0",
-        "@serverless/utils": "^6.7.0",
+        "@serverless/utils": "^5.20.3",
         "chalk": "^4.1.2",
         "child-process-ext": "^2.1.1",
         "chokidar": "^3.5.3",
@@ -18532,7 +18535,8 @@
       },
       "dependencies": {
         "@serverless/utils": {
-          "version": "https://registry.npmjs.org/@serverless/utils/-/utils-5.20.3.tgz",
+          "version": "5.20.3",
+          "resolved": "https://registry.npmjs.org/@serverless/utils/-/utils-5.20.3.tgz",
           "integrity": "sha512-MG3DQJdto+LaeVY9gh/z0xloAfT0h1Y3Pa4/yYcKe8Dy5HYtSujuav0MvTOH18+s2outjKKJDxTh6tZuyNqFDQ==",
           "dev": true,
           "requires": {
@@ -19054,7 +19058,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "adm-zip": {
       "version": "0.5.9",
@@ -19103,7 +19108,8 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-align": {
       "version": "3.0.1",
@@ -19436,9 +19442,9 @@
       }
     },
     "asl-validator": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-3.0.8.tgz",
-      "integrity": "sha512-ku2hkt137ebImA6DNySVoBtymffl/62TQHWKBb54yI3twrcsQyi78fPtvRi+PMob89vLeb0BbGezr5+4rQcJ7Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-3.1.0.tgz",
+      "integrity": "sha512-J2OmT6lkj2RHojDLWyqh33BNCBfpOIAEl1z01cd/4WiGt8Sjgqx+gbX7WsgVKGS4uF/pGwc1EkrZvm0mSRMcWA==",
       "requires": {
         "ajv": "^8.11.0",
         "asl-path-validator": "^0.11.0",
@@ -21191,7 +21197,8 @@
           "version": "7.4.6",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -23444,7 +23451,8 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "isstream": {
       "version": "0.1.2",
@@ -30048,7 +30056,8 @@
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml2js": {
       "version": "0.4.19",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@hapi/joi": "^15.0.2",
     "@serverless/utils": "^6.7.0",
-    "asl-validator": "^3.0.8",
+    "asl-validator": "^3.1.0",
     "bluebird": "^3.4.0",
     "chalk": "^4.1.2",
     "lodash": "^4.17.11"


### PR DESCRIPTION
New version of `asl-validator` is published yesterday https://www.npmjs.com/package/asl-validator

We could potentially update some of new MAP features that were added to the validator.