### PR TITLE
fix: template error while using distributed_map

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -314,6 +314,7 @@ function getStepFunctionsPermissions(state) {
   let stateMachineArn = state.Mode === 'DISTRIBUTED' ? {
     'Fn::Sub': [
       `arn:aws:states:\${AWS::Region}:\${AWS::AccountId}:stateMachine:${state.StateMachineName}`,
+      {},
     ],
   } : null;
 


### PR DESCRIPTION
Issue: 
```The CloudFormation template is invalid: Template error: One or more Fn::Sub intrinsic functions don't specify expected arguments. Specify a string as first argument, and an optional second argument to specify a mapping of values to replace in the string```


This PR fixes the above issue by adding the second argument.