### PR TITLE
Remove accidental camel case in message

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -200,10 +200,10 @@ class ServerlessStepFunctions {
 
     if (this.v3Api) {
       const slsRed = chalk.hex('#fd5750');
-      message += `\n${slsRed('✔')} Serverless StepFunctions OutPuts\n`;
+      message += `\n${slsRed('✔')} Serverless StepFunctions Outputs\n`;
       message += `${chalk.grey('endpoints:')}`;
     } else {
-      message += `${chalk.yellow.underline('Serverless StepFunctions OutPuts')}\n`;
+      message += `${chalk.yellow.underline('Serverless StepFunctions Outputs')}\n`;
       message += `${chalk.yellow('endpoints:')}`;
     }
 

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -326,7 +326,7 @@ describe('#index', () => {
         },
       };
       let expectedMessage = '';
-      expectedMessage += `${chalk.yellow.underline('Serverless StepFunctions OutPuts')}\n`;
+      expectedMessage += `${chalk.yellow.underline('Serverless StepFunctions Outputs')}\n`;
       expectedMessage += `${chalk.yellow('endpoints:')}`;
       expectedMessage += '\n  POST - https://example.com/foo/bar';
       expectedMessage += '\n';
@@ -349,7 +349,7 @@ describe('#index', () => {
         },
       };
       let expectedMessage = '';
-      expectedMessage += `${chalk.yellow.underline('Serverless StepFunctions OutPuts')}\n`;
+      expectedMessage += `${chalk.yellow.underline('Serverless StepFunctions Outputs')}\n`;
       expectedMessage += `${chalk.yellow('endpoints:')}`;
       expectedMessage += '\n  POST - https://example.com/foo/bar';
       expectedMessage += '\n';
@@ -372,7 +372,7 @@ describe('#index', () => {
         },
       };
       let expectedMessage = '';
-      expectedMessage += `${chalk.yellow.underline('Serverless StepFunctions OutPuts')}\n`;
+      expectedMessage += `${chalk.yellow.underline('Serverless StepFunctions Outputs')}\n`;
       expectedMessage += `${chalk.yellow('endpoints:')}`;
       expectedMessage += '\n  POST - https://example.com';
       expectedMessage += '\n';


### PR DESCRIPTION
`<pedantry>`Change `OutPuts` to `Outputs``</pedantry>` 😳