### PR TITLE
feat: add support for step func sdk sync execution

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -440,6 +440,39 @@ function getStepFunctionsPermissions(state) {
   }];
 }
 
+function getStepFunctionsSDKPermissions(state) {
+  let stateMachineArn = state.Mode === 'DISTRIBUTED' ? {
+    'Fn::Sub': [
+      `arn:aws:states:\${AWS::Region}:\${AWS::AccountId}:stateMachine:${state.StateMachineName}`,
+      {},
+    ],
+  } : null;
+
+  if (!stateMachineArn) {
+    stateMachineArn = state.Parameters['StateMachineArn.$'] ? '*'
+      : state.Parameters.StateMachineArn;
+  }
+
+  return [{
+    action: 'states:StartSyncExecution',
+    resource: stateMachineArn,
+  }, {
+    action: 'states:DescribeExecution,states:StopExecution',
+    // this is excessive but mirrors behaviour in the console
+    // also, DescribeExecution supports executions as resources but StopExecution
+    // doesn't support resources
+    resource: '*',
+  }, {
+    action: 'events:PutTargets,events:PutRule,events:DescribeRule',
+    resource: {
+      'Fn::Sub': [
+        'arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule',
+        {},
+      ],
+    },
+  }];
+}
+
 function getCodeBuildPermissions(state) {
   const projectName = state.Parameters.ProjectName;
 
@@ -639,6 +672,9 @@ function getIamPermissions(taskStates) {
       case 'arn:aws:states:::states:startExecution.sync:2':
       case 'arn:aws:states:::states:startExecution.waitForTaskToken':
         return getStepFunctionsPermissions(state);
+
+      case 'arn:aws:states:::aws-sdk:sfn:startSyncExecution':
+        return getStepFunctionsSDKPermissions(state);
 
       case 'arn:aws:states:::codebuild:startBuild':
       case 'arn:aws:states:::codebuild:startBuild.sync':

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -2950,6 +2950,55 @@ describe('#compileIamRole', () => {
     }]);
   });
 
+  it('should give step functions using sdk permissions (too permissive, but mirrors console behavior)', () => {
+    const stateMachineArn = 'arn:aws:states:us-east-1:123456789:stateMachine:HelloStateMachine';
+    const genStateMachine = id => ({
+      id,
+      definition: {
+        StartAt: 'A',
+        States: {
+          A: {
+            Type: 'Task',
+            Resource: 'arn:aws:states:::aws-sdk:sfn:startSyncExecution',
+            Parameters: {
+              StateMachineArn: stateMachineArn,
+              Input: {},
+            },
+            End: true,
+          },
+        },
+      },
+    });
+
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: genStateMachine('StateMachine1'),
+      },
+    };
+
+    serverlessStepFunctions.compileIamRole();
+    const statements = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources.StateMachine1Role
+      .Properties.Policies[0].PolicyDocument.Statement;
+
+    const stateMachinePermissions = statements.filter(s => _.isEqual(s.Action, ['states:StartSyncExecution']));
+    expect(stateMachinePermissions).to.have.lengthOf(1);
+    expect(stateMachinePermissions[0].Resource).to.deep.eq([stateMachineArn]);
+
+    const executionPermissions = statements.filter(s => _.isEqual(s.Action, ['states:DescribeExecution', 'states:StopExecution']));
+    expect(executionPermissions).to.have.lengthOf(1);
+    expect(executionPermissions[0].Resource).to.equal('*');
+
+    const eventPermissions = statements.filter(s => _.isEqual(s.Action, ['events:PutTargets', 'events:PutRule', 'events:DescribeRule']));
+    expect(eventPermissions).to.have.lengthOf(1);
+    expect(eventPermissions[0].Resource).to.deep.eq([{
+      'Fn::Sub': [
+        'arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule',
+        {},
+      ],
+    }]);
+  });
+
   it('should give step functions permission to * whenever StateMachineArn.$ is seen', () => {
     const stateMachineArn = 'arn:aws:states:us-east-1:123456789:stateMachine:HelloStateMachine';
     const genStateMachine = id => ({
@@ -3000,6 +3049,42 @@ describe('#compileIamRole', () => {
       .Properties.Policies[0].PolicyDocument.Statement;
 
     const stateMachinePermissions = statements.filter(s => _.includes(s.Action, 'states:StartExecution'));
+    expect(stateMachinePermissions).to.have.lengthOf(1);
+    expect(stateMachinePermissions[0].Resource).to.equal('*');
+  });
+
+  it('should give step functions using sdk permission to * whenever StateMachineArn.$ is seen', () => {
+    const genStateMachine = id => ({
+      id,
+      definition: {
+        StartAt: 'A',
+        States: {
+          A: {
+            Type: 'Task',
+            Resource: 'arn:aws:states:::aws-sdk:sfn:startSyncExecution',
+            Parameters: {
+              'StateMachineArn.$': '$.arn',
+              Input: {},
+            },
+            End: true,
+          },
+        },
+      },
+    });
+
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: genStateMachine('StateMachine1'),
+      },
+    };
+
+    serverlessStepFunctions.compileIamRole();
+    const statements = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources.StateMachine1Role
+      .Properties.Policies[0].PolicyDocument.Statement;
+
+    const stateMachinePermissions = statements.filter(s => _.includes(s.Action, 'states:StartSyncExecution'));
+
     expect(stateMachinePermissions).to.have.lengthOf(1);
     expect(stateMachinePermissions[0].Resource).to.equal('*');
   });


### PR DESCRIPTION
This PR adds support to generate IAM statements for ```StartSyncExecution``` when using a nested express workflow.

While working with a express stepFunction I needed to generate permissions for a nested express workflow like this: 

```Resource: arn:aws:states:::aws-sdk:sfn:startSyncExecution```. 

After verifying the plugin I noticed it only works for:

```
arn:aws:states:::states:startExecution
arn:aws:states:::states:startExecution.sync
arn:aws:states:::states:startExecution.sync:2
arn:aws:states:::states:startExecution.waitForTaskToken
```
The .sync, .sync:2 and waitForTaskToken are not supported by express workflows.

With this PR we should be able to add the necessary action ```states:StartSyncExecution```.
All I did was to replicate the ```states:startExecution``` for ```aws-sdk:sfn:startSyncExecution```