### PR TITLE
Align policy naming with serverless framework convention?

### DIFF
--- a/lib/naming.js
+++ b/lib/naming.js
@@ -35,8 +35,8 @@ module.exports = {
 
   getStateMachinePolicyName() {
     return [
-      this.provider.getStage(),
       this.provider.serverless.service.service,
+      this.provider.getStage(),
       'statemachine',
     ].join('-');
   },
@@ -77,9 +77,9 @@ module.exports = {
 
   getSchedulePolicyName(stateMachineName) {
     return [
+      this.provider.serverless.service.service,
       this.provider.getStage(),
       this.provider.getRegion(),
-      this.provider.serverless.service.service,
       stateMachineName,
       'schedule',
     ].join('-');
@@ -97,9 +97,9 @@ module.exports = {
 
   getCloudWatchEventPolicyName(stateMachineName) {
     return [
+      this.provider.serverless.service.service,
       this.provider.getStage(),
       this.provider.getRegion(),
-      this.provider.serverless.service.service,
       stateMachineName,
       'event',
     ].join('-');

--- a/lib/naming.test.js
+++ b/lib/naming.test.js
@@ -99,7 +99,7 @@ describe('#naming', () => {
   describe('#getStateMachinePolicyName()', () => {
     it('should use the stage and service name', () => {
       expect(serverlessStepFunctions.getStateMachinePolicyName()).to
-        .equal('dev-step-functions-statemachine');
+        .equal('step-functions-dev-statemachine');
     });
   });
 
@@ -113,7 +113,7 @@ describe('#naming', () => {
   describe('#getApiGatewayName()', () => {
     it('should return apiGatewayName', () => {
       expect(serverlessStepFunctions.getApiGatewayName()).to
-        .equal('dev-step-functions-stepfunctions');
+        .equal('step-functions-dev-stepfunctions');
     });
   });
 
@@ -141,7 +141,7 @@ describe('#naming', () => {
   describe('#getSchedulePolicyName()', () => {
     it('should use the stage and service name', () => {
       expect(serverlessStepFunctions.getSchedulePolicyName('stateMachine')).to
-        .equal('dev-us-east-1-step-functions-stateMachine-schedule');
+        .equal('step-functions-dev-us-east-1-stateMachine-schedule');
     });
   });
 });


### PR DESCRIPTION
Hi, 

I noticed that policies created by serverless-step-functions plugin does not conform to the serverless framework naming convention.

Example serverless framework generated policy name:
`abc-serverless-dev-lambda`
vs one created with serverless-step-functions plugin:
`dev-abc-serverless-statemachine`

I tend to use the service name to restrict on what resources my deployment IAM role can operate by checking for `${service-name}-*` and this behavior breaks this convention that serverless framework follows.

I don't know if this behavior is intentional or not, but I would like to propose this change and see what others think about it.