### PR TITLE
fix: define proper permissions for index with Ref table

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -94,11 +94,22 @@ function getSnsPermissions(serverless, state) {
   return [];
 }
 
-function getDynamoDBArn(tableName) {
+function getDynamoDBArn(tableName, indexName = '') {
   if (isIntrinsic(tableName)) {
     // most likely we'll see a { Ref: LogicalId }, which we need to map to
     // { Fn::GetAtt: [ LogicalId, Arn ] } to get the ARN
     if (tableName.Ref) {
+      if (indexName) {
+        return {
+          'Fn::Join': [
+            '/',
+            [
+              { 'Fn::GetAtt': [tableName.Ref, 'Arn'] },
+              `index/${indexName}`,
+            ],
+          ],
+        };
+      }
       return {
         'Fn::GetAtt': [tableName.Ref, 'Arn'],
       };
@@ -120,7 +131,7 @@ function getDynamoDBArn(tableName) {
                 '/',
                 [
                   'table',
-                  tableName,
+                  indexName ? `${tableName}/index/${indexName}` : tableName,
                 ],
               ],
             },
@@ -139,7 +150,7 @@ function getDynamoDBArn(tableName) {
         'dynamodb',
         { Ref: 'AWS::Region' },
         { Ref: 'AWS::AccountId' },
-        `table/${tableName}`,
+        `table/${indexName ? `${tableName}/index/${indexName}` : tableName}`,
       ],
     ],
   };
@@ -212,7 +223,7 @@ function getDynamoDBPermissions(action, state) {
       ? '*'
       : state.Parameters.IndexName;
 
-    resource = getDynamoDBArn(`${state.Parameters.TableName}/index/${indexName}`);
+    resource = getDynamoDBArn(state.Parameters.TableName, indexName);
   } else {
     resource = getDynamoDBArn(state.Parameters.TableName);
   }

--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -150,7 +150,7 @@ function getDynamoDBArn(tableName, indexName = '') {
         'dynamodb',
         { Ref: 'AWS::Region' },
         { Ref: 'AWS::AccountId' },
-        `table/${indexName ? `${tableName}/index/${indexName}` : tableName}`,
+        indexName ? `table/${tableName}/index/${indexName}` : `table/${tableName}`,
       ],
     ],
   };

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -756,6 +756,15 @@ describe('#compileIamRole', () => {
             },
             End: true,
           },
+          C: {
+            Type: 'Task',
+            Resource: 'arn:aws:states:::aws-sdk:dynamodb:query',
+            Parameters: {
+              TableName: { Ref: tableName },
+              IndexName: 'GSI1',
+            },
+            End: true,
+          },
         },
       },
     });
@@ -780,6 +789,10 @@ describe('#compileIamRole', () => {
 
     expect(policy.PolicyDocument.Statement[0].Resource[1]).to.be.deep.equal({
       'Fn::Join': [':', ['arn', { Ref: 'AWS::Partition' }, 'dynamodb', { Ref: 'AWS::Region' }, { Ref: 'AWS::AccountId' }, 'table/hello/index/GSI1']],
+    });
+
+    expect(policy.PolicyDocument.Statement[0].Resource[2]).to.be.deep.equal({
+      'Fn::Join': ['/', [{ 'Fn::GetAtt': ['hello', 'Arn'] }, 'index/GSI1']],
     });
   });
 


### PR DESCRIPTION
When the "TableName" is a Ref the 'Arn' to use the index is not generated correctly:

```arn:aws:dynamodb:eu-west-1:679049160385:table/[object Object]/index/GsiPkState```

It should be:

```
{'Fn::Join': ['/', [{ 'Fn::GetAtt': ['hello', 'Arn'] }, 'index/GSI1']] }
```