### PR TITLE
fix(deps): bump asl-validator version to address jsonpath-plus vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@serverless/utils": "^6.7.0",
-        "asl-validator": "^3.8.0",
+        "asl-validator": "^3.8.4",
         "bluebird": "^3.4.0",
         "chalk": "^4.1.2",
         "joi": "^17.7.0",
@@ -993,6 +993,28 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.2.1.tgz",
+      "integrity": "sha512-gaHqbubTi29aZpVbBlECRpmdia+L5/lh2BwtIJTmtxdbecEyyX/ejAOg7eQDGNvGOUmPY7Z2Yxdy9ioyH/VJeA==",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.3.tgz",
+      "integrity": "sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
       }
     },
     "node_modules/@kwsites/file-exists": {
@@ -3197,22 +3219,22 @@
       "dev": true
     },
     "node_modules/asl-path-validator": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/asl-path-validator/-/asl-path-validator-0.12.0.tgz",
-      "integrity": "sha512-pzBX2mKp8NQ7p1xM6sfSd2vFQJDX0UdUCun/YcRKMNSv7j93erTomK7iIU79N5rjJD++kPr9qwWhA67pFVpdhA==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/asl-path-validator/-/asl-path-validator-0.14.1.tgz",
+      "integrity": "sha512-Q5P3WLX1sLhTKdMXsgCW6KwKeapozQADq2nhfC6a6/dTVkfj+mL42YS0NGB4cmlvm/qoXjOnElHoBQFjm2ce0g==",
       "dependencies": {
-        "jsonpath-plus": "^7.0.0"
+        "jsonpath-plus": "^10.0.0"
       }
     },
     "node_modules/asl-validator": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-3.8.0.tgz",
-      "integrity": "sha512-xFIPmTS+ehk2AELWnRFHUkRyHRtt75D4AbKHmEqjD+9lZf+gNvIa/cCnABk/1f72JUuo5SoI6i2CXp2a7D08fg==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-3.8.4.tgz",
+      "integrity": "sha512-7nOk/l6VtYQbBgxHcJHYABtgU9dL04beH4o6v2/n1jAD3dkFspx2AVEpgF2+Nz2RterF+sKa9cgyiGR3kHOZmg==",
       "dependencies": {
         "ajv": "^8.12.0",
-        "asl-path-validator": "^0.12.0",
+        "asl-path-validator": "^0.14.1",
         "commander": "^10.0.1",
-        "jsonpath-plus": "^7.2.0",
+        "jsonpath-plus": "^10.0.0",
         "yaml": "^2.3.1"
       },
       "bin": {
@@ -8874,6 +8896,14 @@
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "dev": true
     },
+    "node_modules/jsep": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.3.9.tgz",
+      "integrity": "sha512-i1rBX5N7VPl0eYb6+mHNp52sEuaS2Wi8CDYx1X5sn9naevL78+265XJqy1qENEk7mRKwS06NHpUqiBwR7qeodw==",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -9023,11 +9053,20 @@
       ]
     },
     "node_modules/jsonpath-plus": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
-      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.1.0.tgz",
+      "integrity": "sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.2.1",
+        "@jsep-plugin/regex": "^1.0.3",
+        "jsep": "^1.3.9"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/JSONStream": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "joi": "^17.7.0",
     "@serverless/utils": "^6.7.0",
-    "asl-validator": "^3.8.0",
+    "asl-validator": "^3.8.4",
     "bluebird": "^3.4.0",
     "chalk": "^4.1.2",
     "lodash": "^4.17.11"


### PR DESCRIPTION
The asl-validator package relies on jsonpath-plus as a peer dependency, which contained a known vulnerability (details at https://nvd.nist.gov/vuln/detail/CVE-2024-21534).

This PR resolves the vulnerability by upgrading asl-validator to the latest version, which includes an updated, secure version of jsonpath-plus.