### PR TITLE
Use newer Node.js versions for CI `node-version: 14` -> `node-version: 16`

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.4
         with:
-          node-version: 14
+          node-version: 16
       - run: |
           npm install
       - run: |


### PR DESCRIPTION
Fix for: https://github.com/serverless-operations/serverless-step-functions/actions/runs/11801852739/job/32876143409
https://security.snyk.io/vuln/SNYK-JS-JSONPATHPLUS-7945884