### PR TITLE
Updating the CI environment

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -4,12 +4,12 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2.1.4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 18
       - run: |
           npm install
       - run: |

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           node-version: 18
       - run: |
-          npm install
+          npm install --legacy-peer-deps
       - run: |
           npm run lint
       - run: |


### PR DESCRIPTION
# Overview
Update Node.js version from 14 to 18 in GitHub Actions to resolve compatibility issues with the `Object.hasOwn` method.

## Changes
- Update the libraries in use
- Update Node.js version from 14 to 18
- Modified npm install command to use `--legacy-peer-deps` flag

## Background
The following error occurs when running tests in the current CI environment:


```
 1) #compileStateMachines
       should validate definition and pass:
     TypeError: Object.hasOwn is not a function
      at new JSONPath (node_modules/jsonpath-plus/dist/index-node-cjs.cjs:1530:22)
      at JSONPath (node_modules/jsonpath-plus/dist/index-node-cjs.cjs:1509:14)
      at missingTransitionTargetErrors (node_modules/asl-validator/dist/src/checks/missing-transition-target-errors.js:9:34)
      at validator (node_modules/asl-validator/dist/src/validator.js:35:104)
      at /home/runner/work/serverless-step-functions/serverless-step-functions/lib/deploy/stepFunctions/compileStateMachines.js:119:45
      at Array.forEach (<anonymous>)
      at ServerlessStepFunctions.compileStateMachines (lib/deploy/stepFunctions/compileStateMachines.js:94:34)
      at Context.<anonymous> (lib/deploy/stepFunctions/compileStateMachines.test.js:1394:29)
      at processImmediate (internal/timers.js:464:21)

```

## Impact
- Changes only affect CI/CD environment
- No impact on application code
