### PR TITLE
chore: bump asl-validator to 3.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@serverless/utils": "^6.7.0",
-        "asl-validator": "^3.8.0",
+        "asl-validator": "^3.11.0",
         "bluebird": "^3.4.0",
         "chalk": "^4.1.2",
         "joi": "^17.7.0",
@@ -993,6 +993,30 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
       }
     },
     "node_modules/@kwsites/file-exists": {
@@ -3197,22 +3221,24 @@
       "dev": true
     },
     "node_modules/asl-path-validator": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/asl-path-validator/-/asl-path-validator-0.12.0.tgz",
-      "integrity": "sha512-pzBX2mKp8NQ7p1xM6sfSd2vFQJDX0UdUCun/YcRKMNSv7j93erTomK7iIU79N5rjJD++kPr9qwWhA67pFVpdhA==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/asl-path-validator/-/asl-path-validator-0.15.0.tgz",
+      "integrity": "sha512-rIvxPZOu03VIyDSNkvrjkE8LQZFSCFLfsl43anCNjz/eEsIaCcydhbjyiNIx2dk7gKZ7LqYGeI/B3zWeaf+93Q==",
+      "license": "MIT",
       "dependencies": {
-        "jsonpath-plus": "^7.0.0"
+        "jsonpath-plus": "^10.1.0"
       }
     },
     "node_modules/asl-validator": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-3.8.0.tgz",
-      "integrity": "sha512-xFIPmTS+ehk2AELWnRFHUkRyHRtt75D4AbKHmEqjD+9lZf+gNvIa/cCnABk/1f72JUuo5SoI6i2CXp2a7D08fg==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/asl-validator/-/asl-validator-3.11.0.tgz",
+      "integrity": "sha512-MQ3mfrQiW0uE6QnWY9EMOO29GJGSqmvjiQ45u+Lg9oMBH/pb1HREiRDNSCrBLuHREJbbsZjIC28QN9xUkBZxGw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
-        "asl-path-validator": "^0.12.0",
+        "asl-path-validator": "^0.15.0",
         "commander": "^10.0.1",
-        "jsonpath-plus": "^7.2.0",
+        "jsonpath-plus": "^10.2.0",
         "yaml": "^2.3.1"
       },
       "bin": {
@@ -8874,6 +8900,15 @@
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "dev": true
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -9023,11 +9058,21 @@
       ]
     },
     "node_modules/jsonpath-plus": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
-      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz",
+      "integrity": "sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/JSONStream": {

--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
     "sinon": "^12.0.1"
   },
   "dependencies": {
-    "joi": "^17.7.0",
     "@serverless/utils": "^6.7.0",
-    "asl-validator": "^3.8.0",
+    "asl-validator": "^3.11.0",
     "bluebird": "^3.4.0",
     "chalk": "^4.1.2",
+    "joi": "^17.7.0",
     "lodash": "^4.17.11"
   },
   "peerDependencies": {


### PR DESCRIPTION
This bumps asl-validator to version 3.11.0. This should address the [RCE vulnerability in JSONPath Plus](https://github.com/advisories/GHSA-pppg-cpfq-h7wr). This has already been addressed in the [asl-validator](https://github.com/ChristopheBougere/asl-validator/pull/164) dependency, which depends on jsonpath-plus.