### PR TITLE
feat: support `Arguments` for Lambda when query language is JSONata

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -362,7 +362,7 @@ function getRedshiftDataPermissions(action, state) {
 function getLambdaPermissions(state) {
   // function name can be name-only, name-only with alias, full arn or partial arn
   // https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_RequestParameters
-  const functionName = state.Parameters.FunctionName;
+  const functionName = getParameterOrArgument(state, 'FunctionName');
   if (_.isString(functionName)) {
     const segments = functionName.split(':');
 
@@ -429,10 +429,11 @@ function getLambdaPermissions(state) {
     }];
   }
 
-  if (state.Parameters['FunctionName.$']) {
+  if (getParameterOrArgument(state, 'FunctionName.$')) {
+    const allowedFunctions = getParameterOrArgument(state, 'AllowedFunctions');
     return [{
       action: 'lambda:InvokeFunction',
-      resource: state.Parameters.AllowedFunctions ? state.Parameters.AllowedFunctions : '*',
+      resource: allowedFunctions || '*',
     }];
   }
 

--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -360,9 +360,18 @@ function getRedshiftDataPermissions(action, state) {
 }
 
 function getLambdaPermissions(state) {
+  if (isJsonPathParameter(state, 'FunctionName') || isJsonataArgument(state, 'FunctionName')) {
+    const allowedFunctions = getParameterOrArgument(state, 'AllowedFunctions');
+    return [{
+      action: 'lambda:InvokeFunction',
+      resource: allowedFunctions || '*',
+    }];
+  }
+
   // function name can be name-only, name-only with alias, full arn or partial arn
   // https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html#API_Invoke_RequestParameters
   const functionName = getParameterOrArgument(state, 'FunctionName');
+
   if (_.isString(functionName)) {
     const segments = functionName.split(':');
 
@@ -426,14 +435,6 @@ function getLambdaPermissions(state) {
           ],
         },
       ],
-    }];
-  }
-
-  if (getParameterOrArgument(state, 'FunctionName.$')) {
-    const allowedFunctions = getParameterOrArgument(state, 'AllowedFunctions');
-    return [{
-      action: 'lambda:InvokeFunction',
-      resource: allowedFunctions || '*',
     }];
   }
 

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -3587,6 +3587,41 @@ describe('#compileIamRole', () => {
     ]);
   });
 
+  it('should resolve FunctionName from the Arguments property when there is no Parameters property', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          id: 'StateMachine1',
+          definition: {
+            StartAt: 'A',
+            States: {
+              A: {
+                Type: 'Task',
+                Resource: 'arn:aws:states:::lambda:invoke',
+                Arguments: {
+                  FunctionName: 'arn:aws:lambda:us-west-2:1234567890:function:foo',
+                  Payload: '{% $states.input.Payload %}',
+                },
+                End: true,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    serverlessStepFunctions.compileIamRole();
+    const statements = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources.StateMachine1Role
+      .Properties.Policies[0].PolicyDocument.Statement;
+    const lambdaPermissions = statements.filter(s => _.isEqual(s.Action, ['lambda:InvokeFunction']));
+    expect(lambdaPermissions).to.have.lengthOf(1);
+    expect(lambdaPermissions[0].Resource).to.deep.equal([
+      'arn:aws:lambda:us-west-2:1234567890:function:foo',
+      'arn:aws:lambda:us-west-2:1234567890:function:foo:*',
+    ]);
+  });
+
   it('should support variable FunctionName', () => {
     serverless.service.stepFunctions = {
       stateMachines: {

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -3587,7 +3587,7 @@ describe('#compileIamRole', () => {
     ]);
   });
 
-  it('should resolve FunctionName from the Arguments property when there is no Parameters property', () => {
+  itParam('should resolve FunctionName: ${value}', ['JSONPath', 'JSONata'], (queryLanguage) => {
     serverless.service.stepFunctions = {
       stateMachines: {
         myStateMachine1: {
@@ -3598,10 +3598,17 @@ describe('#compileIamRole', () => {
               A: {
                 Type: 'Task',
                 Resource: 'arn:aws:states:::lambda:invoke',
-                Arguments: {
-                  FunctionName: 'arn:aws:lambda:us-west-2:1234567890:function:foo',
-                  Payload: '{% $states.input.Payload %}',
-                },
+                ...getParamsOrArgs(
+                  queryLanguage,
+                  {
+                    FunctionName: 'arn:aws:lambda:us-west-2:1234567890:function:foo',
+                    'Payload.$': '$.Payload',
+                  },
+                  {
+                    FunctionName: 'arn:aws:lambda:us-west-2:1234567890:function:foo',
+                    Payload: '{% $states.input.Payload %}',
+                  },
+                ),
                 End: true,
               },
             },

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -3629,7 +3629,7 @@ describe('#compileIamRole', () => {
     ]);
   });
 
-  it('should support variable FunctionName', () => {
+  itParam('should support variable FunctionName: ${value}', ['JSONPath', 'JSONata'], (queryLanguage) => {
     serverless.service.stepFunctions = {
       stateMachines: {
         myStateMachine1: {
@@ -3640,26 +3640,47 @@ describe('#compileIamRole', () => {
               A: {
                 Type: 'Task',
                 Resource: 'arn:aws:states:::lambda:invoke.waitForTaskToken',
-                Parameters: {
-                  'FunctionName.$': '$.functionName',
-                  Payload: {
-                    'model.$': '$.new_model',
-                    'token.$': '$$.Task.Token',
+                ...getParamsOrArgs(
+                  queryLanguage,
+                  {
+                    'FunctionName.$': '$.functionName',
+                    Payload: {
+                      'model.$': '$.new_model',
+                      'token.$': '$$.Task.Token',
+                    },
                   },
-                },
+                  {
+                    FunctionName: '{% $states.input.functionName %}',
+                    Payload: {
+                      model: '{% $states.input.new_model %}',
+                      token: '{% $states.context.Task.Token %}',
+                    },
+                  },
+                ),
                 Next: 'B',
               },
               B: {
                 Type: 'Task',
                 Resource: 'arn:aws:states:::lambda:invoke.waitForTaskToken',
-                Parameters: {
-                  'FunctionName.$': '$.functionName',
-                  AllowedFunctions: '*limited*',
-                  Payload: {
-                    'model.$': '$.new_model',
-                    'token.$': '$$.Task.Token',
+                ...getParamsOrArgs(
+                  queryLanguage,
+                  {
+                    'FunctionName.$': '$.functionName',
+                    AllowedFunctions: '*limited*',
+                    Payload: {
+                      'model.$': '$.new_model',
+                      'token.$': '$$.Task.Token',
+                    },
                   },
-                },
+                  {
+                    FunctionName: '{% $states.input.functionName %}',
+                    AllowedFunctions: '*limited*',
+                    Payload: {
+                      model: '{% $states.input.new_model %}',
+                      token: '{% $states.context.Task.Token %}',
+                    },
+                  },
+                ),
                 End: true,
               },
             },
@@ -3685,27 +3706,49 @@ describe('#compileIamRole', () => {
               A: {
                 Type: 'Task',
                 Resource: 'arn:aws:states:::lambda:invoke.waitForTaskToken',
-                Parameters: {
-                  'FunctionName.$': '$.functionName',
-                  AllowedFunctions: 'arn:aws:lambda:us-west-2:1234567890:function:foo',
-                  Payload: {
-                    'model.$': '$.new_model',
-                    'token.$': '$$.Task.Token',
+                ...getParamsOrArgs(
+                  queryLanguage,
+                  {
+                    'FunctionName.$': '$.functionName',
+                    AllowedFunctions: 'arn:aws:lambda:us-west-2:1234567890:function:foo',
+                    Payload: {
+                      'model.$': '$.new_model',
+                      'token.$': '$$.Task.Token',
+                    },
                   },
-                },
+                  {
+                    FunctionName: '{% $states.input.functionName %}',
+                    AllowedFunctions: 'arn:aws:lambda:us-west-2:1234567890:function:foo',
+                    Payload: {
+                      model: '{% $states.input.new_model %}',
+                      token: '{% $states.context.Task.Token %}',
+                    },
+                  },
+                ),
                 Next: 'B',
               },
               B: {
                 Type: 'Task',
                 Resource: 'arn:aws:states:::lambda:invoke.waitForTaskToken',
-                Parameters: {
-                  'FunctionName.$': '$.functionName',
-                  AllowedFunctions: '*limited*',
-                  Payload: {
-                    'model.$': '$.new_model',
-                    'token.$': '$$.Task.Token',
+                ...getParamsOrArgs(
+                  queryLanguage,
+                  {
+                    'FunctionName.$': '$.functionName',
+                    AllowedFunctions: '*limited*',
+                    Payload: {
+                      'model.$': '$.new_model',
+                      'token.$': '$$.Task.Token',
+                    },
                   },
-                },
+                  {
+                    FunctionName: '{% $states.input.functionName %}',
+                    AllowedFunctions: '*limited*',
+                    Payload: {
+                      model: '{% $states.input.new_model %}',
+                      token: '{% $states.context.Task.Token %}',
+                    },
+                  },
+                ),
                 End: true,
               },
             },


### PR DESCRIPTION
When using JSONata as the query language, AWS creates the step definition with `Arguments` instead of `Parameters`.

Example:

```diff
Step name:
  Type: Task
  Resource: arn:aws:states:::lambda:invoke
  Output: '{% $states.result.Payload %}'
- Parameters:
+ Arguments:
    FunctionName: <function ARN goes here>
    Payload: '{% $states.input %}'
```

That leads to the error below

```txt
Deploying "project-name" to stage "staging" (us-east-1)
Layer sharp is already uploaded.
✖ Stack staging-project-name failed to deploy (7s)

✖ TypeError: Cannot read properties of undefined (reading 'FunctionName')
    at ServerlessStepFunctions.getLambdaPermissions (/home/edvaldo/project-name/node_modules/serverless-step-functions/lib/deploy/stepFunctions/compileIamRole.js:365:41)
    at /home/edvaldo/project-name/node_modules/serverless-step-functions/lib/deploy/stepFunctions/compileIamRole.js:775:47
    at arrayMap (/home/edvaldo/project-name/node_modules/lodash/lodash.js:653:23)
    at map (/home/edvaldo/project-name/node_modules/lodash/lodash.js:9622:14)
    at Function.flatMap (/home/edvaldo/project-name/node_modules/lodash/lodash.js:9325:26)
    at ServerlessStepFunctions.getIamPermissions (/home/edvaldo/project-name/node_modules/serverless-step-functions/lib/deploy/stepFunctions/compileIamRole.js:714:12)
    at /home/edvaldo/project-name/node_modules/serverless-step-functions/lib/deploy/stepFunctions/compileIamRole.js:873:56
    at Array.forEach (<anonymous>)
    at ServerlessStepFunctions.compileIamRole (/home/edvaldo/project-name/node_modules/serverless-step-functions/lib/deploy/stepFunctions/compileIamRole.js:861:32)
    at ServerlessStepFunctions.tryCatcher (/home/edvaldo/project-name/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/home/edvaldo/project-name/node_modules/bluebird/js/release/promise.js:547:31)
    at Promise._settlePromise (/home/edvaldo/project-name/node_modules/bluebird/js/release/promise.js:604:18)
    at Promise._settlePromiseCtx (/home/edvaldo/project-name/node_modules/bluebird/js/release/promise.js:641:10)
    at _drainQueueStep (/home/edvaldo/project-name/node_modules/bluebird/js/release/async.js:97:12)
    at _drainQueue (/home/edvaldo/project-name/node_modules/bluebird/js/release/async.js:86:9)
    at Async._drainQueues (/home/edvaldo/project-name/node_modules/bluebird/js/release/async.js:102:5)
```

---

Serverless Framework Version: `4.9.1`
Serverless Step Function Version: `^3.22.0`
Operating System: Windows with WSL