### PR TITLE
chore(deps): update ubuntu image 

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Update CI workflow to use latest ubuntu image since ubuntu-20.04 is deprecated:

https://github.com/actions/runner-images/issues/11101