### PR TITLE
chore: update Node to v20

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - run: |
           npm install --legacy-peer-deps
       - run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,9 @@
         "serverless": "^2.69.1",
         "sinon": "^12.0.1"
       },
+      "engines": {
+        "node": ">=20"
+      },
       "peerDependencies": {
         "serverless": ">=2.32.0"
       }

--- a/package.json
+++ b/package.json
@@ -74,5 +74,8 @@
     "*.js": [
       "eslint"
     ]
+  },
+  "engines": {
+    "node": ">=20"
   }
 }


### PR DESCRIPTION
Update Node.js version from 18 to 20 in GitHub Actions and set an `engines` node Node version in the `package.json` file. 

[AWS currently supports ](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-supported)the following Node.js versions:
- Node.js v22.x (until April 30, 2027)
- Node.js v20.x (until April 30, 2026)
- **Node.js v18.x (until September 1, 2025)**