### PR TITLE
feat(api-gateway): support timeoutInMillis for http events

### DIFF
--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -191,6 +191,7 @@ module.exports = {
         stateMachineObj,
         http,
       ),
+      ...(http && http.timeoutInMillis && { TimeoutInMillis: http.timeoutInMillis }),
     };
 
     let responses;

--- a/lib/deploy/events/apiGateway/methods.test.js
+++ b/lib/deploy/events/apiGateway/methods.test.js
@@ -133,6 +133,21 @@ describe('#methods()', () => {
           .to.equal('\'*\'');
       });
 
+    it('should set TimeoutInMillis when timeoutInMillis is provided',
+      () => {
+        const integration = serverlessStepFunctions.getMethodIntegration('stateMachine', undefined, {
+          timeoutInMillis: 10000,
+        }).Properties.Integration;
+        expect(integration.TimeoutInMillis).to.equal(10000);
+      });
+
+    it('should not set TimeoutInMillis when timeoutInMillis is not provided',
+      () => {
+        const integration = serverlessStepFunctions
+          .getMethodIntegration('stateMachine').Properties.Integration;
+        expect(integration.TimeoutInMillis).to.equal(undefined);
+      });
+
     it('should change passthroughBehavior and action when action is set',
       () => {
         expect(serverlessStepFunctions.getMethodIntegration('stateMachine', 'custom', {

--- a/lib/deploy/events/apiGateway/validate.js
+++ b/lib/deploy/events/apiGateway/validate.js
@@ -21,6 +21,13 @@ module.exports = {
             http.authorizer = this.getAuthorizer(http, stateMachineName);
           }
 
+          if (!http.timeoutInMillis) {
+            const providerTimeout = _.get(this.serverless.service.provider.apiGateway, 'timeoutInMillis');
+            if (providerTimeout) {
+              http.timeoutInMillis = providerTimeout;
+            }
+          }
+
           if (http.cors) {
             http.cors = this.getCors(http);
 

--- a/lib/deploy/events/apiGateway/validate.test.js
+++ b/lib/deploy/events/apiGateway/validate.test.js
@@ -822,4 +822,72 @@ describe('#httpValidate()', () => {
     expect(validated.events[0].http.cors.origin).to.equal('*');
     expect(validated.events[0].http.cors.maxAge).to.equal(86400);
   });
+
+  it('should pass timeoutInMillis from the http event', () => {
+    serverlessStepFunctions.serverless.service.stepFunctions = {
+      stateMachines: {
+        first: {
+          events: [
+            {
+              http: {
+                method: 'POST',
+                path: '/foo/bar',
+                timeoutInMillis: 10000,
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    const validated = serverlessStepFunctions.httpValidate();
+    expect(validated.events[0].http.timeoutInMillis).to.equal(10000);
+  });
+
+  it('should use provider.apiGateway.timeoutInMillis as default when not set on event', () => {
+    serverlessStepFunctions.serverless.service.provider.apiGateway = {
+      timeoutInMillis: 15000,
+    };
+    serverlessStepFunctions.serverless.service.stepFunctions = {
+      stateMachines: {
+        first: {
+          events: [
+            {
+              http: {
+                method: 'POST',
+                path: '/foo/bar',
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    const validated = serverlessStepFunctions.httpValidate();
+    expect(validated.events[0].http.timeoutInMillis).to.equal(15000);
+  });
+
+  it('should prefer event-level timeoutInMillis over provider default', () => {
+    serverlessStepFunctions.serverless.service.provider.apiGateway = {
+      timeoutInMillis: 15000,
+    };
+    serverlessStepFunctions.serverless.service.stepFunctions = {
+      stateMachines: {
+        first: {
+          events: [
+            {
+              http: {
+                method: 'POST',
+                path: '/foo/bar',
+                timeoutInMillis: 5000,
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    const validated = serverlessStepFunctions.httpValidate();
+    expect(validated.events[0].http.timeoutInMillis).to.equal(5000);
+  });
 });


### PR DESCRIPTION
## Summary

- Adds support for `timeoutInMillis` on individual `http` events to set the API Gateway integration timeout
- Adds support for `provider.apiGateway.timeoutInMillis` as a default for all events
- Event-level config takes precedence over the provider default

## Usage

```yaml
provider:
  apiGateway:
    timeoutInMillis: 15000 # default for all step function http events

stepFunctions:
  stateMachines:
    hello:
      events:
        - http:
            path: /hello
            method: GET
            timeoutInMillis: 29000 # override per event
```

## Test plan

- [x] `should set TimeoutInMillis when timeoutInMillis is provided`
- [x] `should not set TimeoutInMillis when timeoutInMillis is not provided`
- [x] `should pass timeoutInMillis from the http event`
- [x] `should use provider.apiGateway.timeoutInMillis as default when not set on event`
- [x] `should prefer event-level timeoutInMillis over provider default`
- [x] Full test suite passes (432 tests)

Closes #651

🤖 Generated with [Claude Code](https://claude.ai/claude-code)