### PR TITLE
fix(iam): generate IAM policy for aws-sdk:dynamodb:scan resource

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -767,6 +767,8 @@ function getIamPermissions(taskStates) {
         return getDynamoDBPermissions('dynamodb:UpdateTable', state);
       case 'arn:aws:states:::aws-sdk:dynamodb:query':
         return getDynamoDBPermissions('dynamodb:Query', state);
+      case 'arn:aws:states:::aws-sdk:dynamodb:scan':
+        return getDynamoDBPermissions('dynamodb:Scan', state);
 
       case 'arn:aws:states:::aws-sdk:dynamodb:batchGetItem':
         return getBatchDynamoDBPermissions('dynamodb:BatchGetItem', state);

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -890,6 +890,43 @@ describe('#compileIamRole', () => {
     expect(policy.PolicyDocument.Statement[0].Resource[0]).to.equal('*');
   });
 
+  itParam('should give dynamodb:Scan permission for aws-sdk:dynamodb:scan resource: ${value}', ['JSONPath', 'JSONata'], (queryLanguage) => {
+    const helloTable = 'hello';
+
+    const genStateMachine = (id, tableName) => ({
+      id,
+      definition: {
+        StartAt: 'A',
+        States: {
+          A: {
+            Type: 'Task',
+            Resource: 'arn:aws:states:::aws-sdk:dynamodb:scan',
+            ...getParamsOrArgs(queryLanguage, { TableName: tableName }),
+            End: true,
+          },
+        },
+      },
+    });
+
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: genStateMachine('StateMachine1', helloTable),
+      },
+    };
+
+    serverlessStepFunctions.compileIamRole();
+    const policy = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources.StateMachine1Role
+      .Properties.Policies[0];
+
+    expect(policy.PolicyDocument.Statement[0].Action)
+      .to.be.deep.equal(['dynamodb:Scan']);
+
+    expect(policy.PolicyDocument.Statement[0].Resource[0]).to.be.deep.equal({
+      'Fn::Join': [':', ['arn', { Ref: 'AWS::Partition' }, 'dynamodb', { Ref: 'AWS::Region' }, { Ref: 'AWS::AccountId' }, 'table/hello']],
+    });
+  });
+
   itParam('should give batch dynamodb permission for only tables referenced by state machine: ${value}', ['JSONPath', 'JSONata'], (queryLanguage) => {
     const helloTable = 'hello';
     const helloTableArn = {


### PR DESCRIPTION
## Summary

- Adds missing `arn:aws:states:::aws-sdk:dynamodb:scan` case to the IAM policy switch in `compileIamRole.js`
- Generates correct `dynamodb:Scan` permission scoped to the referenced table

Fixes #584

## Test plan

- [ ] New unit tests added for both JSONPath and JSONata query languages, asserting `dynamodb:Scan` action and correct table ARN resource

🤖 Generated with [Claude Code](https://claude.com/claude-code)