### PR TITLE
feat(iam): generate IAM policy for http:invoke (Call third-party API) states

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -614,6 +614,28 @@ function getEventBridgePermissions(state) {
   ];
 }
 
+function getHttpInvokePermissions(state) {
+  const auth = state.Parameters && state.Parameters.Authentication;
+  const connectionArn = (auth && auth.ConnectionArn) || '*';
+
+  return [
+    {
+      action: 'states:InvokeHTTPEndpoint',
+      resource: '*',
+    },
+    {
+      action: 'events:RetrieveConnectionCredentials',
+      resource: connectionArn,
+    },
+    {
+      action: 'secretsmanager:GetSecretValue,secretsmanager:DescribeSecret',
+      resource: {
+        'Fn::Sub': 'arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:events!connection/*',
+      },
+    },
+  ];
+}
+
 function getEventBridgeSchedulerPermissions(state) {
   const scheduleGroupName = state.Parameters.GroupName;
   const scheduleTargetRoleArn = state.Parameters.Target.RoleArn;
@@ -828,6 +850,9 @@ function getIamPermissions(taskStates) {
 
       case 'arn:aws:states:::aws-sdk:scheduler:createSchedule':
         return getEventBridgeSchedulerPermissions(state);
+
+      case 'arn:aws:states:::http:invoke':
+        return getHttpInvokePermissions(state);
 
       case 'arn:aws:states:::s3:getObject':
       case 'arn:aws:states:::aws-sdk:s3:getObject':

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -4398,6 +4398,94 @@ describe('#compileIamRole', () => {
     expect(rolePermissions[0].Resource).to.deep.eq(['arn:aws:iam::${AWS::AccountId}:role/MyIAMRole']);
   });
 
+  it('should give http:invoke permissions with static ConnectionArn', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          id: 'StateMachine1',
+          definition: {
+            StartAt: 'A',
+            States: {
+              A: {
+                Type: 'Task',
+                Resource: 'arn:aws:states:::http:invoke',
+                Parameters: {
+                  ApiEndpoint: 'https://api.example.com/endpoint',
+                  Method: 'GET',
+                  Authentication: {
+                    ConnectionArn: 'arn:aws:events:us-east-1:123456789012:connection/my-connection/abc',
+                  },
+                },
+                End: true,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    serverlessStepFunctions.compileIamRole();
+    const statements = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources.StateMachine1Role
+      .Properties.Policies[0].PolicyDocument.Statement;
+
+    const invokePermissions = statements.filter(s => _.isEqual(s.Action, ['states:InvokeHTTPEndpoint']));
+    expect(invokePermissions).to.have.lengthOf(1);
+    expect(invokePermissions[0].Resource).to.equal('*');
+
+    const connectionPermissions = statements.filter(s => _.isEqual(s.Action, ['events:RetrieveConnectionCredentials']));
+    expect(connectionPermissions).to.have.lengthOf(1);
+    expect(connectionPermissions[0].Resource).to.deep.equal(['arn:aws:events:us-east-1:123456789012:connection/my-connection/abc']);
+
+    const secretsPermissions = statements.filter(
+      s => _.isEqual(s.Action, ['secretsmanager:GetSecretValue', 'secretsmanager:DescribeSecret']),
+    );
+    expect(secretsPermissions).to.have.lengthOf(1);
+    expect(secretsPermissions[0].Resource).to.deep.equal([{
+      'Fn::Sub': 'arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:events!connection/*',
+    }]);
+  });
+
+  it('should give http:invoke permissions with dynamic ConnectionArn (JSONPath)', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          id: 'StateMachine1',
+          definition: {
+            StartAt: 'A',
+            States: {
+              A: {
+                Type: 'Task',
+                Resource: 'arn:aws:states:::http:invoke',
+                Parameters: {
+                  'ApiEndpoint.$': '$.apiUrl',
+                  'Method.$': '$.method',
+                  Authentication: {
+                    'ConnectionArn.$': '$.connectionArn',
+                  },
+                },
+                End: true,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    serverlessStepFunctions.compileIamRole();
+    const statements = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources.StateMachine1Role
+      .Properties.Policies[0].PolicyDocument.Statement;
+
+    // When ConnectionArn is dynamic, both states:InvokeHTTPEndpoint and
+    // events:RetrieveConnectionCredentials have resource '*', so they get
+    // consolidated into a single statement by the permission consolidator.
+    const wildcardPermissions = statements.filter(s => s.Resource === '*');
+    expect(wildcardPermissions).to.have.lengthOf(1);
+    expect(wildcardPermissions[0].Action).to.include('states:InvokeHTTPEndpoint');
+    expect(wildcardPermissions[0].Action).to.include('events:RetrieveConnectionCredentials');
+  });
+
   it('should handle permissionsBoundary', () => {
     serverless.service.stepFunctions = {
       stateMachines: {


### PR DESCRIPTION
## Summary

- Adds IAM policy generation for `arn:aws:states:::http:invoke` Task states (AWS Step Functions HTTP endpoints / "Call third-party API")
- Generates the three permissions required by AWS:
  - `states:InvokeHTTPEndpoint` on `*`
  - `events:RetrieveConnectionCredentials` on the static `ConnectionArn` if provided, or `*` if it is a dynamic JSONPath/JSONata reference
  - `secretsmanager:GetSecretValue` + `secretsmanager:DescribeSecret` on the EventBridge Connections secrets prefix (`events!connection/*`)

Fixes #599

## Test plan

- [ ] New test: static `ConnectionArn` — verifies each permission statement individually
- [ ] New test: dynamic `ConnectionArn.$` (JSONPath) — verifies that `states:InvokeHTTPEndpoint` and `events:RetrieveConnectionCredentials` are consolidated into a single `*` resource statement
- [ ] Full test suite passes (`npm test` — 439 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)