### PR TITLE
fix(iam): generate IAM policy for aws-sdk:sesv2:sendEmail resource

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -839,6 +839,9 @@ function getIamPermissions(taskStates) {
       case 'arn:aws:states:::aws-sdk:s3:listObjectsV2':
         return getS3ObjectPermissions('s3:listObjectsV2', state);
 
+      case 'arn:aws:states:::aws-sdk:sesv2:sendEmail':
+        return [{ action: 'ses:SendEmail', resource: '*' }];
+
       default:
         if (isIntrinsic(state.Resource) || !!state.Resource.match(/arn:aws(-[a-z]+)*:lambda/)) {
           const trimmedArn = trimAliasFromLambdaArn(state.Resource);

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -4177,6 +4177,47 @@ describe('#compileIamRole', () => {
     }]);
   });
 
+  it('should give ses:SendEmail permission for aws-sdk:sesv2:sendEmail', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          id: 'StateMachine1',
+          definition: {
+            StartAt: 'A',
+            States: {
+              A: {
+                Type: 'Task',
+                Resource: 'arn:aws:states:::aws-sdk:sesv2:sendEmail',
+                Parameters: {
+                  FromEmailAddress: 'sender@example.com',
+                  Destination: {
+                    ToAddresses: ['recipient@example.com'],
+                  },
+                  Content: {
+                    Simple: {
+                      Subject: { Data: 'Hello' },
+                      Body: { Text: { Data: 'World' } },
+                    },
+                  },
+                },
+                End: true,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    serverlessStepFunctions.compileIamRole();
+    const statements = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources.StateMachine1Role
+      .Properties.Policies[0].PolicyDocument.Statement;
+
+    expect(statements).to.have.lengthOf(1);
+    expect(statements[0].Action).to.deep.equal(['ses:SendEmail']);
+    expect(statements[0].Resource).to.equal('*');
+  });
+
   it('should give bedrock invoke permissions for foundation models', () => {
     serverless.service.stepFunctions = {
       stateMachines: {


### PR DESCRIPTION
## Summary

- Adds a missing case for `arn:aws:states:::aws-sdk:sesv2:sendEmail` in the IAM policy generator
- Generates `ses:SendEmail` on `*` instead of logging "Cannot generate IAM policy statement"

Fixes #610

## Test plan

- [ ] New test: verifies `ses:SendEmail` permission is generated for `aws-sdk:sesv2:sendEmail` states
- [ ] Full test suite passes (`npm test` — 438 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)