### PR TITLE
fix(notifications): resolve local function names to CloudFormation logical IDs

### DIFF
--- a/lib/deploy/stepFunctions/compileNotifications.js
+++ b/lib/deploy/stepFunctions/compileNotifications.js
@@ -5,6 +5,7 @@ const crypto = require('crypto');
 const BbPromise = require('bluebird');
 const schema = require('./compileNotifications.schema');
 const logger = require('../../utils/logger');
+const { translateLocalFunctionNames } = require('../../utils/aws');
 
 const executionStatuses = [
   'ABORTED', 'FAILED', 'RUNNING', 'SUCCEEDED', 'TIMED_OUT',
@@ -264,9 +265,26 @@ function* compilePermissionResources(stateMachineLogicalId, iamRoleLogicalId, ta
   }
 }
 
-function* compileResources(stateMachineLogicalId, stateMachineName, notificationsObj, rolePath) {
+// Recursively walk a target object and apply translateFn to any Ref/Fn::GetAtt
+// intrinsic that refers to a local serverless function name.
+function normalizeIntrinsicRefs(value, translateFn) {
+  if (_.isArray(value)) return value.map(v => normalizeIntrinsicRefs(v, translateFn));
+  if (_.isObject(value)) {
+    if (value.Ref || value['Fn::GetAtt']) return translateFn(value);
+    return _.mapValues(value, v => normalizeIntrinsicRefs(v, translateFn));
+  }
+  return value;
+}
+
+function* compileResources(
+  stateMachineLogicalId, stateMachineName, notificationsObj, rolePath, translateFn,
+) {
   const iamRoleLogicalId = `${stateMachineLogicalId}NotificationsIamRole`;
-  const allTargets = _.flatMap(executionStatuses, status => _.get(notificationsObj,
+  const normalizedNotificationsObj = _.mapValues(
+    notificationsObj,
+    targets => (targets || []).map(target => normalizeIntrinsicRefs(target, translateFn)),
+  );
+  const allTargets = _.flatMap(executionStatuses, status => _.get(normalizedNotificationsObj,
     status, []).map(target => ({ status, target })));
   const permissions = compilePermissionResources(
     stateMachineLogicalId, iamRoleLogicalId, allTargets, rolePath,
@@ -282,7 +300,7 @@ function* compileResources(stateMachineLogicalId, stateMachineName, notification
     : undefined;
 
   for (const status of executionStatuses) {
-    const targets = notificationsObj[status];
+    const targets = normalizedNotificationsObj[status];
     if (!_.isEmpty(targets)) {
       const cfnTargets = targets.map((t, index) => compileTarget(stateMachineName,
         status, t, index, iamRoleLogicalId));
@@ -356,11 +374,13 @@ module.exports = {
       }
 
       const rolePath = _.get(this.serverless.service, 'provider.iam.role.path');
+      const translateFn = translateLocalFunctionNames.bind(this);
       const resourcesIterator = compileResources(
         stateMachineLogicalId,
         stateMachineName,
         notificationsObj,
         rolePath,
+        translateFn,
       );
 
       return Array.from(resourcesIterator);

--- a/lib/deploy/stepFunctions/compileNotifications.test.js
+++ b/lib/deploy/stepFunctions/compileNotifications.test.js
@@ -523,6 +523,62 @@ describe('#compileNotifications', () => {
       .to.equal(true);
   });
 
+  it('should resolve local function names via Fn::GetAtt in notifications to CloudFormation logical IDs', () => {
+    serverless.service.functions = {
+      'send-email-on-failure': { handler: 'path/to/file.handler' },
+    };
+
+    const lambdaArn = { 'Fn::GetAtt': ['send-email-on-failure', 'Arn'] };
+    const targets = [{ lambda: lambdaArn }];
+
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myWorkflow: genStateMachineWithTargets('MyWorkflow', targets),
+      },
+    };
+
+    serverlessStepFunctions.compileNotifications();
+    const resources = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources;
+
+    const expectedLogicalId = 'SendDashemailDashonDashfailureLambdaFunction';
+    const expectedArn = { 'Fn::GetAtt': [expectedLogicalId, 'Arn'] };
+
+    // The EventRule target Arn should use the normalized logical ID
+    const eventRule = resources.MyWorkflowNotificationsFAILEDEventRule;
+    expect(eventRule.Properties.Targets[0].Arn).to.deep.equal(expectedArn);
+
+    // The Lambda permission should also use the normalized logical ID
+    validateHasLambdaPermission(resources, expectedArn);
+  });
+
+  it('should resolve local function names via Ref in notifications to CloudFormation logical IDs', () => {
+    serverless.service.functions = {
+      'send-email-on-failure': { handler: 'path/to/file.handler' },
+    };
+
+    const lambdaRef = { Ref: 'send-email-on-failure' };
+    const targets = [{ lambda: lambdaRef }];
+
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myWorkflow: genStateMachineWithTargets('MyWorkflow', targets),
+      },
+    };
+
+    serverlessStepFunctions.compileNotifications();
+    const resources = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources;
+
+    const expectedLogicalId = 'SendDashemailDashonDashfailureLambdaFunction';
+    const expectedRef = { Ref: expectedLogicalId };
+
+    const eventRule = resources.MyWorkflowNotificationsFAILEDEventRule;
+    expect(eventRule.Properties.Targets[0].Arn).to.deep.equal(expectedRef);
+
+    validateHasLambdaPermission(resources, expectedRef);
+  });
+
   it('should apply provider.iam.role.path to notifications IAM role', () => {
     serverless.service.stepFunctions = {
       stateMachines: {


### PR DESCRIPTION
## Summary

- Fixes #582
- When using `Fn::GetAtt` or `Ref` with a local serverless function name (e.g. `send-email-on-failure`) inside a `notifications` target, the name is now translated to its normalized CloudFormation logical ID (e.g. `SendDashemailDashonDashfailureLambdaFunction`)
- Uses a recursive walk of each target object to apply `translateLocalFunctionNames` to any `Ref`/`Fn::GetAtt` intrinsic, covering all target types and nesting levels — consistent with how state machine `Resource` references are already handled in `compileStateMachines.js`

## Test plan

- [ ] New test: `should resolve local function names via Fn::GetAtt in notifications to CloudFormation logical IDs`
- [ ] New test: `should resolve local function names via Ref in notifications to CloudFormation logical IDs`
- [ ] All 439 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)