### PR TITLE
fix(iam): use ${AWS::Partition} in S3 resource ARNs

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -669,7 +669,7 @@ function resolveS3BucketReference(bucket, resource) {
     };
   }
 
-  return resource.replaceAll('${bucket}', bucket);
+  return { 'Fn::Sub': resource.replaceAll('${bucket}', bucket) };
 }
 
 function resolveS3BucketReferences(bucket, resources) {
@@ -689,26 +689,26 @@ function getS3ObjectPermissions(action, state) {
         resource: resolveS3BucketReferences(bucket, [
           // The bucket variable is not interpolated here, or below,
           // but inside resolveS3BucketReferences() to also handle intrinsics
-          'arn:aws:s3:::${bucket}',
-          'arn:aws:s3:::${bucket}/*',
+          'arn:${AWS::Partition}:s3:::${bucket}',
+          'arn:${AWS::Partition}:s3:::${bucket}/*',
         ]),
       },
       {
         action: 's3:List*',
         resource: resolveS3BucketReferences(bucket, [
-          'arn:aws:s3:::${bucket}',
-          'arn:aws:s3:::${bucket}/*',
+          'arn:${AWS::Partition}:s3:::${bucket}',
+          'arn:${AWS::Partition}:s3:::${bucket}/*',
         ]),
       },
     ];
   }
 
   if (prefix) {
-    arn = resolveS3BucketReference(bucket, `arn:aws:s3:::\${bucket}/${prefix}/${key}`);
+    arn = resolveS3BucketReference(bucket, `arn:\${AWS::Partition}:s3:::\${bucket}/${prefix}/${key}`);
   } else if (bucket === '*' && key === '*') {
     arn = '*';
   } else {
-    arn = resolveS3BucketReference(bucket, `arn:aws:s3:::\${bucket}/${key}`);
+    arn = resolveS3BucketReference(bucket, `arn:\${AWS::Partition}:s3:::\${bucket}/${key}`);
   }
 
   return [{

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -1920,9 +1920,9 @@ describe('#compileIamRole', () => {
     const policy1 = resources.StateMachine1Role.Properties.Policies[0];
     const policy2 = resources.StateMachine2Role.Properties.Policies[0];
     expect(policy1.PolicyDocument.Statement[0].Resource)
-      .to.be.deep.equal([`arn:aws:s3:::${testBucket}/${hello}`]);
+      .to.be.deep.equal([{ 'Fn::Sub': `arn:\${AWS::Partition}:s3:::${testBucket}/${hello}` }]);
     expect(policy2.PolicyDocument.Statement[0].Resource)
-      .to.be.deep.equal([`arn:aws:s3:::${testBucket}/${world}`]);
+      .to.be.deep.equal([{ 'Fn::Sub': `arn:\${AWS::Partition}:s3:::${testBucket}/${world}` }]);
 
     [policy1, policy2].forEach((policy) => {
       expect(policy.PolicyDocument.Statement[0].Action)
@@ -1983,9 +1983,9 @@ describe('#compileIamRole', () => {
     const policy1 = resources.StateMachine1Role.Properties.Policies[0];
     const policy2 = resources.StateMachine2Role.Properties.Policies[0];
     expect(policy1.PolicyDocument.Statement[1].Resource)
-      .to.be.deep.equal([`arn:aws:s3:::${testBucket}/${hello}`]);
+      .to.be.deep.equal([{ 'Fn::Sub': `arn:\${AWS::Partition}:s3:::${testBucket}/${hello}` }]);
     expect(policy2.PolicyDocument.Statement[1].Resource)
-      .to.be.deep.equal([`arn:aws:s3:::${testBucket}/${world}`]);
+      .to.be.deep.equal([{ 'Fn::Sub': `arn:\${AWS::Partition}:s3:::${testBucket}/${world}` }]);
   });
 
   it('should give s3:GetObject permission to * when Bucket.$ and Key.$ are seen on ItemReader', () => {
@@ -2109,9 +2109,9 @@ describe('#compileIamRole', () => {
     const policy1 = resources.StateMachine1Role.Properties.Policies[0];
     const policy2 = resources.StateMachine2Role.Properties.Policies[0];
     expect(policy1.PolicyDocument.Statement[1].Resource)
-      .to.be.deep.equal([`arn:aws:s3:::${testBucket}/${hello}/*`]);
+      .to.be.deep.equal([{ 'Fn::Sub': `arn:\${AWS::Partition}:s3:::${testBucket}/${hello}/*` }]);
     expect(policy2.PolicyDocument.Statement[1].Resource)
-      .to.be.deep.equal([`arn:aws:s3:::${testBucket}/${world}/*`]);
+      .to.be.deep.equal([{ 'Fn::Sub': `arn:\${AWS::Partition}:s3:::${testBucket}/${world}/*` }]);
   });
 
   it('should give s3:PutObject permission to * when Bucket.$ and Prefix.$ are seen on ResultWriter', () => {
@@ -2216,7 +2216,45 @@ describe('#compileIamRole', () => {
       .compiledCloudFormationTemplate.Resources.StateMachine1Role.Properties.Policies[0]
       .PolicyDocument.Statement;
 
-    expect(statements[0].Resource[0]).to.equal(`arn:aws:s3:::${literalBucket}/${literalKey}`);
+    expect(statements[0].Resource[0]).to.deep.equal({
+      'Fn::Sub': `arn:\${AWS::Partition}:s3:::${literalBucket}/${literalKey}`,
+    });
+  });
+
+  it('should use ${AWS::Partition} in S3 ARNs for partition-aware deployments', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          id: 'StateMachine1',
+          definition: {
+            StartAt: 'A',
+            States: {
+              A: {
+                Type: 'Task',
+                Resource: 'arn:aws:states:::s3:listObjectsV2',
+                Parameters: {
+                  Bucket: 'my-bucket',
+                  Prefix: 'data/',
+                },
+                End: true,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    serverlessStepFunctions.compileIamRole();
+    const statements = serverlessStepFunctions.serverless.service.provider
+      .compiledCloudFormationTemplate.Resources.StateMachine1Role.Properties.Policies[0]
+      .PolicyDocument.Statement;
+
+    expect(statements[0].Resource[0]).to.deep.equal({
+      'Fn::Sub': 'arn:${AWS::Partition}:s3:::my-bucket',
+    });
+    expect(statements[0].Resource[1]).to.deep.equal({
+      'Fn::Sub': 'arn:${AWS::Partition}:s3:::my-bucket/*',
+    });
   });
 
   it('should resolve CloudFormation reference buckets in S3 permissions', () => {
@@ -2251,7 +2289,7 @@ describe('#compileIamRole', () => {
 
     expect(statements[0].Resource[0]).to.deep.equal({
       'Fn::Sub': [
-        'arn:aws:s3:::${bucket}/test-key.txt',
+        'arn:${AWS::Partition}:s3:::${bucket}/test-key.txt',
         { bucket: bucketRef },
       ],
     });
@@ -2290,7 +2328,7 @@ describe('#compileIamRole', () => {
 
     expect(statements[0].Resource[0]).to.deep.equal({
       'Fn::Sub': [
-        'arn:aws:s3:::${bucket}/output.json',
+        'arn:${AWS::Partition}:s3:::${bucket}/output.json',
         { bucket: bucketRef },
       ],
     });
@@ -2343,13 +2381,13 @@ describe('#compileIamRole', () => {
 
     expect(statements[3].Resource[0]).to.deep.equal({
       'Fn::Sub': [
-        'arn:aws:s3:::${bucket}',
+        'arn:${AWS::Partition}:s3:::${bucket}',
         { bucket: bucketRef },
       ],
     });
     expect(statements[3].Resource[1]).to.deep.equal({
       'Fn::Sub': [
-        'arn:aws:s3:::${bucket}/*',
+        'arn:${AWS::Partition}:s3:::${bucket}/*',
         { bucket: bucketRef },
       ],
     });
@@ -2402,13 +2440,15 @@ describe('#compileIamRole', () => {
 
     // First statement for s3:GetObject with literal bucket
     expect(statements[0].Action).to.deep.equal(['s3:GetObject']);
-    expect(statements[0].Resource[0]).to.equal(`arn:aws:s3:::${literalBucket}/${literalFile}`);
+    expect(statements[0].Resource[0]).to.deep.equal({
+      'Fn::Sub': `arn:\${AWS::Partition}:s3:::${literalBucket}/${literalFile}`,
+    });
 
     // Second statement for s3:PutObject with reference bucket
     expect(statements[1].Action).to.deep.equal(['s3:PutObject']);
     expect(statements[1].Resource[0]).to.deep.equal({
       'Fn::Sub': [
-        'arn:aws:s3:::${bucket}/file2.txt',
+        'arn:${AWS::Partition}:s3:::${bucket}/file2.txt',
         { bucket: bucketRef },
       ],
     });
@@ -2458,7 +2498,7 @@ describe('#compileIamRole', () => {
 
     expect(statements[1].Resource[0]).to.deep.equal({
       'Fn::Sub': [
-        'arn:aws:s3:::${bucket}/results/*',
+        'arn:${AWS::Partition}:s3:::${bucket}/results/*',
         { bucket: bucketRef },
       ],
     });
@@ -4666,8 +4706,8 @@ describe('#compileIamRole', () => {
     expect(statements[3].Effect).to.equal('Allow');
     expect(statements[3].Action[0]).to.equal('s3:Get*');
     expect(statements[3].Action[1]).to.equal('s3:List*');
-    expect(statements[3].Resource[0]).to.equal(`arn:aws:s3:::${myBucket}`);
-    expect(statements[3].Resource[1]).to.equal(`arn:aws:s3:::${myBucket}/*`);
+    expect(statements[3].Resource[0]).to.deep.equal({ 'Fn::Sub': `arn:\${AWS::Partition}:s3:::${myBucket}` });
+    expect(statements[3].Resource[1]).to.deep.equal({ 'Fn::Sub': `arn:\${AWS::Partition}:s3:::${myBucket}/*` });
   });
 
   it('should add permissions for KMS key if present', () => {


### PR DESCRIPTION
## Summary

- S3 resource ARNs in generated IAM policies were hardcoded to the `aws` partition, breaking deployments to China (`aws-cn`) and GovCloud (`aws-us-gov`) regions
- Literal bucket names now produce `{ Fn::Sub: 'arn:${AWS::Partition}:s3:::...' }` instead of a plain `arn:aws:s3:::...` string
- Intrinsic bucket references (already using `Fn::Sub` array form) just needed the partition token added to the template

## Test plan

- [x] New test: `listObjectsV2` with a literal bucket produces `${AWS::Partition}` in both resource ARNs
- [x] Existing `resolveS3BucketReference` tests updated to expect partition-aware output
- [x] Full test suite passes (447 tests)
- [x] Lint clean

Closes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)