### PR TITLE
fix(apiGateway): use string type for SelectionPattern in integration responses

### DIFF
--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -206,13 +206,13 @@ module.exports = {
       responses = {
         200: {
           statusCode: 200,
-          selectionPattern: 200,
+          selectionPattern: '',
           responseParameters,
           responseTemplates,
         },
         400: {
           statusCode: 400,
-          selectionPattern: 400,
+          selectionPattern: '400',
           responseParameters: {},
           responseTemplates: {},
         },
@@ -227,7 +227,7 @@ module.exports = {
       const responseParameters = _.get(value, 'responseParameters', {});
       const responseTemplates = _.get(value, 'responseTemplates', {});
       const statusCode = _.get(value, 'statusCode', _.toInteger(key));
-      const selectionPattern = _.get(value, 'selectionPattern', _.toInteger(key));
+      const selectionPattern = _.get(value, 'selectionPattern', _.toString(key));
 
       integrationResponse.IntegrationResponses.push({
         StatusCode: statusCode,

--- a/lib/deploy/events/apiGateway/methods.test.js
+++ b/lib/deploy/events/apiGateway/methods.test.js
@@ -98,6 +98,22 @@ describe('#methods()', () => {
         .to.have.property('Integration');
     });
 
+    it('should use string SelectionPattern values in default integration responses', () => {
+      const integrationResponses = serverlessStepFunctions
+        .getMethodIntegration('stateMachine')
+        .Properties.Integration.IntegrationResponses;
+
+      integrationResponses.forEach((response) => {
+        expect(response.SelectionPattern).to.be.a('string');
+      });
+
+      const successResponse = integrationResponses.find(r => r.StatusCode === 200);
+      expect(successResponse.SelectionPattern).to.equal('');
+
+      const errorResponse = integrationResponses.find(r => r.StatusCode === 400);
+      expect(errorResponse.SelectionPattern).to.equal('400');
+    });
+
     it('should set stateMachinelogical ID to RequestTemplates when customName is not set', () => {
       expect(serverlessStepFunctions.getMethodIntegration('stateMachine').Properties
         .Integration.RequestTemplates['application/json']['Fn::Sub'][1].StateMachineArn.Ref)


### PR DESCRIPTION
## Summary

- `SelectionPattern` values in API Gateway integration responses were emitted as integers, causing AWS to reject the CloudFormation deployment with `Invalid type for parameter selectionPattern, value: 200, type: <class 'int'>, valid types: <class 'str'>`
- The success (200) response now uses `''` (empty string — the API Gateway catch-all pattern)
- The default error (400) response now uses `'400'` (string)
- The fallback default in `_.get(value, 'selectionPattern', ...)` now uses `_.toString(key)` instead of `_.toInteger(key)` for custom response entries

## Test plan

- [x] New test: default integration responses have string `SelectionPattern` values, with `''` for 200 and `'400'` for 400
- [x] Full test suite passes (446 tests)
- [x] Lint clean

Closes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)