### PR TITLE
fix: return promise from compileStateMachines to suppress Bluebird warning

### DIFF
--- a/lib/deploy/stepFunctions/compileStateMachines.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.js
@@ -280,9 +280,8 @@ module.exports = {
           _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs,
             newStateMachineOutPutObject);
         }
-
-        return BbPromise.resolve();
       });
     }
+    return BbPromise.resolve();
   },
 };

--- a/lib/deploy/stepFunctions/compileStateMachines.test.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.test.js
@@ -1860,4 +1860,19 @@ describe('#compileStateMachines', () => {
     expect(encryptionConfiguration.KmsDataKeyReusePeriodSeconds).to.equal(10);
     expect(encryptionConfiguration.Type).to.equal('MANAGED');
   });
+
+  it('should return a resolved promise', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          name: 'myStateMachine1',
+          definition: 'definition1',
+        },
+      },
+    };
+
+    const result = serverlessStepFunctions.compileStateMachines();
+    expect(result).to.have.property('then').that.is.a('function');
+    return result;
+  });
 });


### PR DESCRIPTION
## Summary

- `BbPromise.resolve()` was returned from inside a `forEach` callback — `forEach` discards return values, so Bluebird saw a promise created in a handler that was never chained and emitted a warning
- All work inside the callback is synchronous, so the promise belongs at the function level, not inside the loop
- Moved `return BbPromise.resolve()` to after the `forEach`, correctly signalling completion to the Serverless lifecycle hook runner

## Test plan

- [x] New test: `compileStateMachines()` returns a thenable (resolved promise)
- [x] Full test suite passes (446 tests)
- [x] Lint clean

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)