### PR TITLE
test(stateMachines): add validation test for Map state with ItemProcessor in DISTRIBUTED mode

### DIFF
--- a/lib/deploy/stepFunctions/compileStateMachines.test.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.test.js
@@ -1415,6 +1415,41 @@ describe('#compileStateMachines', () => {
     expect(() => serverlessStepFunctions.compileStateMachines()).to.throw(Error);
   });
 
+  it('should validate Map state with ItemProcessor in DISTRIBUTED mode and pass', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          definition: {
+            StartAt: 'MyMapState',
+            States: {
+              MyMapState: {
+                Type: 'Map',
+                ItemProcessor: {
+                  ProcessorConfig: {
+                    Mode: 'DISTRIBUTED',
+                    ExecutionType: 'STANDARD',
+                  },
+                  StartAt: 'MyTask',
+                  States: {
+                    MyTask: {
+                      Type: 'Task',
+                      Resource: 'arn:aws:lambda:us-east-1:123456789012:function:my-function',
+                      End: true,
+                    },
+                  },
+                },
+                End: true,
+              },
+            },
+          },
+        },
+      },
+      validate: true,
+    };
+    // Definition is valid (DISTRIBUTED mode with ItemProcessor), should not throw (issue #540)
+    serverlessStepFunctions.compileStateMachines();
+  });
+
   it('should replace pseudo parameters that starts with #', () => {
     const definition = {
       StartAt: 'A',


### PR DESCRIPTION
## Summary
- Adds a regression test for #540 — `validate: true` was incorrectly rejecting Map states using `ItemProcessor` with `ProcessorConfig.Mode: DISTRIBUTED`
- The fix was already merged; this test guards against future regressions

## Test plan
- [ ] `npx mocha lib/deploy/stepFunctions/compileStateMachines.test.js --grep "DISTRIBUTED"` passes

Closes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)