### PR TITLE
fix(iam): restrict DescribeExecution and StopExecution to specific state machine executions

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -461,6 +461,25 @@ function getStateMachineArn(state) {
   return stateMachineArn;
 }
 
+function getExecutionArn(stateMachineArn) {
+  if (stateMachineArn === '*') {
+    return '*';
+  }
+  if (typeof stateMachineArn === 'string') {
+    return `${stateMachineArn.replace(':stateMachine:', ':execution:')}:*`;
+  }
+  if (stateMachineArn['Fn::Sub']) {
+    const [template, vars] = stateMachineArn['Fn::Sub'];
+    return {
+      'Fn::Sub': [
+        `${template.replace(':stateMachine:', ':execution:')}:*`,
+        vars,
+      ],
+    };
+  }
+  return '*';
+}
+
 function getStepFunctionsPermissions(state) {
   let stateMachineArn = state.Mode === 'DISTRIBUTED' ? {
     'Fn::Sub': [
@@ -478,10 +497,7 @@ function getStepFunctionsPermissions(state) {
     resource: stateMachineArn,
   }, {
     action: 'states:DescribeExecution,states:StopExecution',
-    // this is excessive but mirrors behaviour in the console
-    // also, DescribeExecution supports executions as resources but StopExecution
-    // doesn't support resources
-    resource: '*',
+    resource: getExecutionArn(stateMachineArn),
   }, {
     action: 'events:PutTargets,events:PutRule,events:DescribeRule',
     resource: {
@@ -510,10 +526,7 @@ function getStepFunctionsSDKPermissions(state) {
     resource: stateMachineArn,
   }, {
     action: 'states:DescribeExecution,states:StopExecution',
-    // this is excessive but mirrors behaviour in the console
-    // also, DescribeExecution supports executions as resources but StopExecution
-    // doesn't support resources
-    resource: '*',
+    resource: getExecutionArn(stateMachineArn),
   }, {
     action: 'events:PutTargets,events:PutRule,events:DescribeRule',
     resource: {

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -3158,7 +3158,7 @@ describe('#compileIamRole', () => {
     }]);
   });
 
-  describe('should give step functions permissions (too permissive, but mirrors console behaviour)', () => {
+  describe('should give step functions permissions', () => {
     it('jsonpath', () => {
       const stateMachineArn = 'arn:aws:states:us-east-1:123456789:stateMachine:HelloStateMachine';
       const genStateMachine = id => ({
@@ -3223,7 +3223,7 @@ describe('#compileIamRole', () => {
 
       const executionPermissions = statements.filter(s => _.isEqual(s.Action, ['states:DescribeExecution', 'states:StopExecution']));
       expect(executionPermissions).to.have.lengthOf(1);
-      expect(executionPermissions[0].Resource).to.equal('*');
+      expect(executionPermissions[0].Resource).to.deep.eq(['arn:aws:states:us-east-1:123456789:execution:HelloStateMachine:*']);
 
       const eventPermissions = statements.filter(s => _.isEqual(s.Action, ['events:PutTargets', 'events:PutRule', 'events:DescribeRule']));
       expect(eventPermissions).to.have.lengthOf(1);
@@ -3300,7 +3300,7 @@ describe('#compileIamRole', () => {
 
       const executionPermissions = statements.filter(s => _.isEqual(s.Action, ['states:DescribeExecution', 'states:StopExecution']));
       expect(executionPermissions).to.have.lengthOf(1);
-      expect(executionPermissions[0].Resource).to.equal('*');
+      expect(executionPermissions[0].Resource).to.deep.eq(['arn:aws:states:us-east-1:123456789:execution:HelloStateMachine:*']);
 
       const eventPermissions = statements.filter(s => _.isEqual(s.Action, ['events:PutTargets', 'events:PutRule', 'events:DescribeRule']));
       expect(eventPermissions).to.have.lengthOf(1);
@@ -3358,7 +3358,7 @@ describe('#compileIamRole', () => {
 
       const executionPermissions = statements.filter(s => _.isEqual(s.Action, ['states:DescribeExecution', 'states:StopExecution']));
       expect(executionPermissions).to.have.lengthOf(1);
-      expect(executionPermissions[0].Resource).to.equal('*');
+      expect(executionPermissions[0].Resource).to.deep.eq(['arn:aws:states:us-east-1:123456789:execution:HelloStateMachine:*']);
 
       const eventPermissions = statements.filter(s => _.isEqual(s.Action, ['events:PutTargets', 'events:PutRule', 'events:DescribeRule']));
       expect(eventPermissions).to.have.lengthOf(1);
@@ -3371,7 +3371,7 @@ describe('#compileIamRole', () => {
     });
   });
 
-  describe('should give step functions using sdk permissions (too permissive, but mirrors console behavior)', () => {
+  describe('should give step functions using sdk permissions', () => {
     it('jsonpath', () => {
       const stateMachineArn = 'arn:aws:states:us-east-1:123456789:stateMachine:HelloStateMachine';
       const genStateMachine = id => ({
@@ -3409,7 +3409,7 @@ describe('#compileIamRole', () => {
 
       const executionPermissions = statements.filter(s => _.isEqual(s.Action, ['states:DescribeExecution', 'states:StopExecution']));
       expect(executionPermissions).to.have.lengthOf(1);
-      expect(executionPermissions[0].Resource).to.equal('*');
+      expect(executionPermissions[0].Resource).to.deep.eq(['arn:aws:states:us-east-1:123456789:execution:HelloStateMachine:*']);
 
       const eventPermissions = statements.filter(s => _.isEqual(s.Action, ['events:PutTargets', 'events:PutRule', 'events:DescribeRule']));
       expect(eventPermissions).to.have.lengthOf(1);
@@ -3459,7 +3459,7 @@ describe('#compileIamRole', () => {
 
       const executionPermissions = statements.filter(s => _.isEqual(s.Action, ['states:DescribeExecution', 'states:StopExecution']));
       expect(executionPermissions).to.have.lengthOf(1);
-      expect(executionPermissions[0].Resource).to.equal('*');
+      expect(executionPermissions[0].Resource).to.deep.eq(['arn:aws:states:us-east-1:123456789:execution:HelloStateMachine:*']);
 
       const eventPermissions = statements.filter(s => _.isEqual(s.Action, ['events:PutTargets', 'events:PutRule', 'events:DescribeRule']));
       expect(eventPermissions).to.have.lengthOf(1);


### PR DESCRIPTION
## Summary

Fixes #514.

- `states:DescribeExecution` and `states:StopExecution` were previously granted on `*`
- They are now scoped to executions of the respective state machine (e.g. `arn:...:execution:StateMachineName:*`)
- When the state machine ARN is dynamic (JSONPath `StateMachineArn.$` or JSONata expression), falls back to `*` as before

## Test plan

- [ ] Existing tests updated to assert specific execution ARN instead of `*`
- [ ] All 446 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)