### PR TITLE
feat(notifications): support InputPath and InputTransformer on notification targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,29 @@ CloudFormation intrinsic functions such as `Ref` and `Fn::GetAtt` are supported.
 
 When setting up a notification target against a FIFO SQS queue, the queue must enable the content-based deduplication option and you must configure the `messageGroupId`.
 
+You can also control the event payload delivered to each notification target using `inputPath` or `inputTransformer`:
+
+```yml
+stepFunctions:
+  stateMachines:
+    hellostepfunc1:
+      name: test
+      definition:
+        ...
+      notifications:
+        FAILED:
+          - sns: SNS_TOPIC_ARN
+            inputTransformer:
+              inputPathsMap:
+                status: '$.detail.status'
+                name: '$.detail.name'
+              inputTemplate: '"State machine <name> finished with status <status>"'
+          - sqs: SQS_QUEUE_ARN
+            inputPath: '$.detail'
+```
+
+`inputPath` selects a sub-tree of the event to pass to the target. `inputTransformer` lets you map fields from the event and embed them in a custom template string.
+
 ### Blue green deployment
 
 To implement a [blue-green deployment with Step Functions](https://theburningmonk.com/2019/08/how-to-do-blue-green-deployment-for-step-functions/) you need to reference the exact versions of the functions.

--- a/lib/deploy/stepFunctions/compileNotifications.js
+++ b/lib/deploy/stepFunctions/compileNotifications.js
@@ -53,43 +53,50 @@ function generatePolicyName(status, targetType, action, resource) {
 }
 
 function compileTarget(stateMachineName, status, targetObj, targetIndex, iamRoleLogicalId) {
+  const inputOptions = {
+    ...(targetObj.inputPath && { InputPath: targetObj.inputPath }),
+    ...(targetObj.inputTransformer && {
+      InputTransformer: {
+        InputPathsMap: targetObj.inputTransformer.inputPathsMap,
+        InputTemplate: targetObj.inputTransformer.inputTemplate,
+      },
+    }),
+  };
+
   // SQS and Kinesis are special cases as they can have additional props
   if (_.has(targetObj, 'sqs.arn')) {
-    const target = {
-      Arn: targetObj.sqs.arn,
-      SqsParameters: {
-        MessageGroupId: targetObj.sqs.messageGroupId,
-      },
+    const Arn = targetObj.sqs.arn;
+    return {
+      Arn,
+      Id: generateTargetId({ Arn }, targetIndex, stateMachineName, status),
+      SqsParameters: { MessageGroupId: targetObj.sqs.messageGroupId },
+      ...inputOptions,
     };
-    target.Id = generateTargetId(target, targetIndex, stateMachineName, status);
-    return target;
   } if (_.has(targetObj, 'kinesis.arn')) {
-    const target = {
-      Arn: targetObj.kinesis.arn,
-      KinesisParameters: {
-        PartitionKeyPath: targetObj.kinesis.partitionKeyPath,
-      },
+    const Arn = targetObj.kinesis.arn;
+    return {
+      Arn,
+      Id: generateTargetId({ Arn }, targetIndex, stateMachineName, status),
+      KinesisParameters: { PartitionKeyPath: targetObj.kinesis.partitionKeyPath },
+      ...inputOptions,
     };
-    target.Id = generateTargetId(target, targetIndex, stateMachineName, status);
-    return target;
   } if (_.has(targetObj, 'stepFunctions')) {
-    const target = {
-      Arn: targetObj.stepFunctions,
-      RoleArn: {
-        'Fn::GetAtt': [iamRoleLogicalId, 'Arn'],
-      },
+    const Arn = targetObj.stepFunctions;
+    return {
+      Arn,
+      Id: generateTargetId({ Arn }, targetIndex, stateMachineName, status),
+      RoleArn: { 'Fn::GetAtt': [iamRoleLogicalId, 'Arn'] },
+      ...inputOptions,
     };
-    target.Id = generateTargetId(target, targetIndex, stateMachineName, status);
-    return target;
   }
 
   const targetType = supportedTargets.find(t => _.has(targetObj, t));
-  const arn = _.get(targetObj, targetType);
-  const target = {
-    Arn: arn,
+  const Arn = _.get(targetObj, targetType);
+  return {
+    Arn,
+    Id: generateTargetId({ Arn }, targetIndex, stateMachineName, status),
+    ...inputOptions,
   };
-  target.Id = generateTargetId(target, targetIndex, stateMachineName, status);
-  return target;
 }
 
 function compileSnsPolicy(status, snsTarget) {

--- a/lib/deploy/stepFunctions/compileNotifications.schema.js
+++ b/lib/deploy/stepFunctions/compileNotifications.schema.js
@@ -31,6 +31,11 @@ const kinesisWithParams = Joi.object().keys({
   partitionKeyPath: Joi.string(),
 });
 
+const inputTransformer = Joi.object().keys({
+  inputPathsMap: Joi.object().pattern(Joi.string(), Joi.string()),
+  inputTemplate: Joi.string().required(),
+});
+
 const target = Joi.object().keys({
   sns: arn,
   sqs: Joi.alternatives().try(sqsWithParams, arn),
@@ -38,6 +43,8 @@ const target = Joi.object().keys({
   firehose: arn,
   lambda: arn,
   stepFunctions: arn,
+  inputPath: Joi.string(),
+  inputTransformer,
 });
 
 const targets = Joi.array().items(target);

--- a/lib/deploy/stepFunctions/compileNotifications.test.js
+++ b/lib/deploy/stepFunctions/compileNotifications.test.js
@@ -579,6 +579,56 @@ describe('#compileNotifications', () => {
     validateHasLambdaPermission(resources, expectedRef);
   });
 
+  it('should support inputPath on notification targets', () => {
+    const targets = [
+      { sns: 'SNS_TOPIC_ARN', inputPath: '$.detail' },
+      { sqs: 'SQS_QUEUE_ARN', inputPath: '$.detail' },
+    ];
+
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myWorkflow: genStateMachineWithTargets('MyWorkflow', targets),
+      },
+    };
+
+    serverlessStepFunctions.compileNotifications();
+    const resources = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources;
+
+    const eventRule = resources.MyWorkflowNotificationsABORTEDEventRule;
+    expect(eventRule.Properties.Targets[0].InputPath).to.equal('$.detail');
+    expect(eventRule.Properties.Targets[1].InputPath).to.equal('$.detail');
+  });
+
+  it('should support inputTransformer on notification targets', () => {
+    const targets = [
+      {
+        sns: 'SNS_TOPIC_ARN',
+        inputTransformer: {
+          inputPathsMap: { status: '$.detail.status', name: '$.detail.name' },
+          inputTemplate: '"State machine <name> finished with status <status>"',
+        },
+      },
+    ];
+
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myWorkflow: genStateMachineWithTargets('MyWorkflow', targets),
+      },
+    };
+
+    serverlessStepFunctions.compileNotifications();
+    const resources = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources;
+
+    const eventRule = resources.MyWorkflowNotificationsABORTEDEventRule;
+    const cfnTarget = eventRule.Properties.Targets[0];
+    expect(cfnTarget.InputTransformer).to.deep.equal({
+      InputPathsMap: { status: '$.detail.status', name: '$.detail.name' },
+      InputTemplate: '"State machine <name> finished with status <status>"',
+    });
+  });
+
   it('should apply provider.iam.role.path to notifications IAM role', () => {
     serverless.service.stepFunctions = {
       stateMachines: {


### PR DESCRIPTION
## Summary
- Adds `inputPath` and `inputTransformer` as optional fields on all notification targets
- Both are passed through to the generated `AWS::Events::Rule` target as `InputPath` / `InputTransformer`
- Schema updated to validate the new fields

## Example
```yaml
notifications:
  FAILED:
    - sns: !Ref MyTopic
      inputTransformer:
        inputPathsMap:
          status: '$.detail.status'
          name: '$.detail.name'
        inputTemplate: '"State machine <name> finished with status <status>"'
    - sqs: MY_QUEUE_ARN
      inputPath: '$.detail'
```

## Test plan
- [ ] `npx mocha lib/deploy/stepFunctions/compileNotifications.test.js` passes

Closes #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)