### PR TITLE
feat(events): add RetryPolicy support for EventBridge rule targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Serverless Framework v2.32.0 or later is required.
     - [Specifying a custom CloudWatch EventBus](#specifying-a-custom-cloudwatch-eventbus)
     - [Specifying a custom EventBridge EventBus](#specifying-a-custom-eventbridge-eventbus)
     - [Specifying a DeadLetterQueue](#specifying-a-deadletterqueue)
+    - [Specifying a RetryPolicy](#specifying-a-retrypolicy)
 - [Tags](#tags)
 - [Commands](#commands)
   - [deploy](#deploy)
@@ -1500,6 +1501,33 @@ Then
   # to get the Arn of the 2nd EventBridge rule
   !GetAtt Hellostepfunc1EventsRuleCloudWatchEvent2.Arn
 ```
+
+#### Specifying a RetryPolicy
+
+You can configure a retry policy for `schedule` and `eventBridge`/`cloudwatchEvent` rule targets. This controls how EventBridge retries failed invocations before sending the event to a dead-letter queue (if configured).
+
+```yml
+stepFunctions:
+  stateMachines:
+    myMachine:
+      events:
+        - schedule:
+            rate: rate(10 minutes)
+            retryPolicy:
+              maximumEventAgeInSeconds: 3600
+              maximumRetryAttempts: 3
+        - eventBridge:
+            event:
+              source:
+                - aws.ec2
+            retryPolicy:
+              maximumEventAgeInSeconds: 7200
+              maximumRetryAttempts: 5
+      definition:
+        ...
+```
+
+Both `maximumEventAgeInSeconds` (60–86400) and `maximumRetryAttempts` (0–185) are optional. When omitted, AWS applies its default retry behaviour.
 
 ## Tags
 

--- a/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.js
+++ b/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.js
@@ -27,6 +27,7 @@ module.exports = {
             let InputPathsMap;
             let InputTemplate;
             let DeadLetterConfig;
+            let RetryPolicy;
 
             if (typeof eventRule === 'object') {
               if (!eventRule.event) {
@@ -53,6 +54,12 @@ module.exports = {
               EventBusName = JSON.stringify(eventRule.eventBusName);
               IamRole = JSON.stringify(eventRule.iamRole);
               DeadLetterConfig = JSON.stringify(eventRule.deadLetterConfig);
+              RetryPolicy = eventRule.retryPolicy
+                ? JSON.stringify({
+                  MaximumEventAgeInSeconds: eventRule.retryPolicy.maximumEventAgeInSeconds,
+                  MaximumRetryAttempts: eventRule.retryPolicy.maximumRetryAttempts,
+                })
+                : undefined;
 
               if ([Input, InputPath, InputTransformer].filter(Boolean).length > 1) {
                 const errorMessage = [
@@ -117,6 +124,7 @@ module.exports = {
                     "Arn": { "Ref": "${stateMachineLogicalId}" },
                     "Id": "${cloudWatchId}",
                     ${DeadLetterConfig ? `"DeadLetterConfig":{ "Arn" : ${DeadLetterConfig} },` : ''}
+                    ${RetryPolicy ? `"RetryPolicy": ${RetryPolicy},` : ''}
                     ${IamRole ? `"RoleArn": ${IamRole}` : `"RoleArn": {
                       "Fn::GetAtt": [
                         "${cloudWatchIamRoleLogicalId}",

--- a/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.test.js
+++ b/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.test.js
@@ -609,6 +609,65 @@ describe('awsCompileCloudWatchEventEvents', () => {
         .Properties.Path).to.equal('/teamA/');
     });
 
+    itParam('should set RetryPolicy on target when retryPolicy is given', ['cloudwatchEvent', 'eventBridge'], (source) => {
+      serverlessStepFunctions.serverless.service.stepFunctions = {
+        stateMachines: {
+          first: {
+            events: [
+              {
+                [source]: {
+                  event: {
+                    source: ['aws.ec2'],
+                    'detail-type': ['EC2 Instance State-change Notification'],
+                    detail: { state: ['pending'] },
+                  },
+                  retryPolicy: {
+                    maximumEventAgeInSeconds: 3600,
+                    maximumRetryAttempts: 3,
+                  },
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      serverlessStepFunctions.compileCloudWatchEventEvents();
+
+      const target = serverlessStepFunctions.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleCloudWatchEvent1
+        .Properties.Targets[0];
+      expect(target.RetryPolicy.MaximumEventAgeInSeconds).to.equal(3600);
+      expect(target.RetryPolicy.MaximumRetryAttempts).to.equal(3);
+    });
+
+    itParam('should not set RetryPolicy on target when retryPolicy is not given', ['cloudwatchEvent', 'eventBridge'], (source) => {
+      serverlessStepFunctions.serverless.service.stepFunctions = {
+        stateMachines: {
+          first: {
+            events: [
+              {
+                [source]: {
+                  event: {
+                    source: ['aws.ec2'],
+                    'detail-type': ['EC2 Instance State-change Notification'],
+                    detail: { state: ['pending'] },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      serverlessStepFunctions.compileCloudWatchEventEvents();
+
+      const target = serverlessStepFunctions.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.FirstEventsRuleCloudWatchEvent1
+        .Properties.Targets[0];
+      expect(target.RetryPolicy).to.equal(undefined);
+    });
+
     it('should not create corresponding resources when events are not given', () => {
       serverlessStepFunctions.serverless.service.stepFunctions = {
         stateMachines: {

--- a/lib/deploy/events/schedule/compileScheduledEvents.js
+++ b/lib/deploy/events/schedule/compileScheduledEvents.js
@@ -28,6 +28,7 @@ module.exports = {
             let Description;
             let method;
             let timezone;
+            let RetryPolicy;
 
             // TODO validate rate syntax
             if (typeof event.schedule === 'object') {
@@ -55,6 +56,12 @@ module.exports = {
               Description = event.schedule.description;
               method = event.schedule.method || METHOD_EVENT_BUS;
               timezone = event.schedule.timezone;
+              RetryPolicy = event.schedule.retryPolicy
+                ? JSON.stringify({
+                  MaximumEventAgeInSeconds: event.schedule.retryPolicy.maximumEventAgeInSeconds,
+                  MaximumRetryAttempts: event.schedule.retryPolicy.maximumRetryAttempts,
+                })
+                : undefined;
 
               if ([Input, InputPath, InputTransformer].filter(Boolean).length > 1) {
                 const errorMessage = [
@@ -219,6 +226,7 @@ module.exports = {
                     },` : ''}
                     "Arn": { "Ref": "${stateMachineLogicalId}" },
                     "Id": "${scheduleId}",
+                    ${RetryPolicy ? `"RetryPolicy": ${RetryPolicy},` : ''}
                     "RoleArn": ${roleArn}
                   }]
                 }

--- a/lib/deploy/events/schedule/compileScheduledEvents.test.js
+++ b/lib/deploy/events/schedule/compileScheduledEvents.test.js
@@ -580,4 +580,55 @@ describe('#httpValidate()', () => {
     };
     expect(() => serverlessStepFunctions.compileScheduledEvents()).to.throw(Error);
   });
+
+  it('should set RetryPolicy on eventBus target when retryPolicy is given', () => {
+    serverlessStepFunctions.serverless.service.stepFunctions = {
+      stateMachines: {
+        first: {
+          events: [
+            {
+              schedule: {
+                rate: 'rate(10 minutes)',
+                retryPolicy: {
+                  maximumEventAgeInSeconds: 7200,
+                  maximumRetryAttempts: 5,
+                },
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    serverlessStepFunctions.compileScheduledEvents();
+
+    const target = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources
+      .FirstStepFunctionsEventsRuleSchedule1.Properties.Targets[0];
+    expect(target.RetryPolicy.MaximumEventAgeInSeconds).to.equal(7200);
+    expect(target.RetryPolicy.MaximumRetryAttempts).to.equal(5);
+  });
+
+  it('should not set RetryPolicy on eventBus target when retryPolicy is not given', () => {
+    serverlessStepFunctions.serverless.service.stepFunctions = {
+      stateMachines: {
+        first: {
+          events: [
+            {
+              schedule: {
+                rate: 'rate(10 minutes)',
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    serverlessStepFunctions.compileScheduledEvents();
+
+    const target = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources
+      .FirstStepFunctionsEventsRuleSchedule1.Properties.Targets[0];
+    expect(target.RetryPolicy).to.equal(undefined);
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `retryPolicy` configuration to `schedule` (eventBus method) and `cloudwatchEvent`/`eventBridge` events
- Emits a CloudFormation `RetryPolicy` on the `AWS::Events::Rule` target with `MaximumEventAgeInSeconds` and `MaximumRetryAttempts`

Closes #575

## Example

```yaml
stateMachines:
  myMachine:
    events:
      - schedule:
          rate: rate(10 minutes)
          retryPolicy:
            maximumEventAgeInSeconds: 3600
            maximumRetryAttempts: 3
      - eventBridge:
          event:
            source:
              - aws.ec2
          retryPolicy:
            maximumEventAgeInSeconds: 7200
            maximumRetryAttempts: 5
```

## Test plan

- [x] Unit tests added for `compileCloudWatchEventEvents` (cloudwatchEvent + eventBridge)
- [x] Unit tests added for `compileScheduledEvents` (eventBus method)
- [x] Verified `RetryPolicy` is absent when `retryPolicy` is not configured
- [x] Full test suite passes (452 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)