### PR TITLE
fix(stateMachines): omit Destinations from LoggingConfiguration when not provided

### DIFF
--- a/lib/deploy/stepFunctions/compileStateMachines.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.js
@@ -201,17 +201,17 @@ module.exports = {
         }
 
         if (value.loggingConfig) {
-          const Destinations = (value.loggingConfig.destinations || [])
-            .map(arn => ({
+          LoggingConfiguration = {
+            Level: value.loggingConfig.level,
+            IncludeExecutionData: value.loggingConfig.includeExecutionData,
+          };
+          if (value.loggingConfig.destinations && value.loggingConfig.destinations.length > 0) {
+            LoggingConfiguration.Destinations = value.loggingConfig.destinations.map(arn => ({
               CloudWatchLogsLogGroup: {
                 LogGroupArn: arn,
               },
             }));
-          LoggingConfiguration = {
-            Level: value.loggingConfig.level,
-            IncludeExecutionData: value.loggingConfig.includeExecutionData,
-            Destinations,
-          };
+          }
         }
 
         if (value.tracingConfig) {

--- a/lib/deploy/stepFunctions/compileStateMachines.test.js
+++ b/lib/deploy/stepFunctions/compileStateMachines.test.js
@@ -1539,6 +1539,43 @@ describe('#compileStateMachines', () => {
     });
   });
 
+  it('should omit Destinations from logging configuration when not provided', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          name: 'stateMachineBeta1',
+          loggingConfig: {
+            level: 'OFF',
+          },
+          definition: {
+            StartAt: 'A',
+            States: {
+              A: {
+                Type: 'Task',
+                Resource: 'arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:hello',
+                End: true,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    serverlessStepFunctions.compileStateMachines();
+    const actual = serverlessStepFunctions
+      .serverless
+      .service
+      .provider
+      .compiledCloudFormationTemplate
+      .Resources
+      .StateMachineBeta1
+      .Properties;
+
+    expect(actual).to.haveOwnProperty('LoggingConfiguration');
+    expect(actual.LoggingConfiguration.Level).to.equal('OFF');
+    expect(actual.LoggingConfiguration).not.to.haveOwnProperty('Destinations');
+  });
+
   it('should compile tracing configuration', () => {
     serverless.service.stepFunctions = {
       stateMachines: {


### PR DESCRIPTION
## Summary

- When `loggingConfig.level` is `OFF` and `destinations` is omitted, the plugin was emitting `"Destinations": []` which CloudFormation rejects with *"expected minimum item count: 1, found: 0"*
- Fix: only include `Destinations` in the compiled `LoggingConfiguration` when the array is non-empty
- Added a test covering the `level: OFF` with no destinations case

Fixes #458

## Test plan

- [ ] New test `should omit Destinations from logging configuration when not provided` passes
- [ ] Existing `should compile logging configuration` test still passes (destinations still emitted when provided)
- [ ] `npm test` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)