### PR TITLE
fix(alarms): allow Fn::Sub in alarm topic ARNs

### DIFF
--- a/lib/deploy/stepFunctions/compileAlarms.schema.js
+++ b/lib/deploy/stepFunctions/compileAlarms.schema.js
@@ -25,6 +25,12 @@ const arn = Joi.alternatives().try(
       ),
     ),
   }),
+  Joi.object().keys({
+    'Fn::Sub': Joi.alternatives().try(
+      Joi.string(),
+      Joi.array().items(Joi.string(), Joi.object()),
+    ),
+  }),
 );
 
 const topics = Joi.object().keys({

--- a/lib/deploy/stepFunctions/compileAlarms.test.js
+++ b/lib/deploy/stepFunctions/compileAlarms.test.js
@@ -630,4 +630,31 @@ describe('#compileAlarms', () => {
     expect(resources.StateMachineBeta1ExecutionsFailedAlarm.Properties.Period).to.equal(3600);
     expect(consoleLogSpy.callCount).equal(0);
   });
+
+  it('should support Fn::Sub in alarm topics', () => {
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: {
+          name: 'stateMachineBeta1',
+          definition: { StartAt: 'A', States: { A: { Type: 'Pass', End: true } } },
+          alarms: {
+            topics: {
+              alarm: { 'Fn::Sub': 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:foo-sns-topic' },
+            },
+            metrics: ['executionsFailed'],
+          },
+        },
+      },
+    };
+
+    serverlessStepFunctions.compileAlarms();
+    const resources = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources;
+
+    expect(resources).to.have.property('StateMachineBeta1ExecutionsFailedAlarm');
+    validateCloudWatchAlarm(resources.StateMachineBeta1ExecutionsFailedAlarm);
+    expect(resources.StateMachineBeta1ExecutionsFailedAlarm.Properties.AlarmActions)
+      .to.deep.equal([{ 'Fn::Sub': 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:foo-sns-topic' }]);
+    expect(consoleLogSpy.callCount).equal(0);
+  });
 });


### PR DESCRIPTION
## Summary

- Extends the alarm ARN schema to accept `Fn::Sub` (both string and array forms) as a valid value for `topics.ok`, `topics.alarm`, and `topics.insufficientData`
- Users can now reference pseudo-parameters like `${AWS::Region}` and `${AWS::AccountId}` without the deprecated `serverless-pseudo-parameters` plugin

## Test plan

- [x] Added test verifying `Fn::Sub` string form passes schema validation and is passed through to `AlarmActions` in the CloudFormation output
- [x] All 15 existing alarm tests continue to pass

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)