### PR TITLE
fix(iam): support intrinsic functions as StateMachineArn in JSONata Arguments

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -449,9 +449,10 @@ function getStateMachineArn(state) {
   let stateMachineArn;
 
   if (state.Arguments) {
-    stateMachineArn = state.Arguments.StateMachineArn.trim().startsWith('{%')
+    const arnValue = state.Arguments.StateMachineArn;
+    stateMachineArn = typeof arnValue === 'string' && arnValue.trim().startsWith('{%')
       ? '*'
-      : state.Arguments.StateMachineArn;
+      : arnValue;
   } else {
     stateMachineArn = state.Parameters['StateMachineArn.$']
       ? '*'

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -3312,6 +3312,53 @@ describe('#compileIamRole', () => {
       }]);
     });
 
+    it('jsonata: should support intrinsic functions (Ref, Fn::GetAtt) as StateMachineArn in Arguments', () => {
+      const refArn = { Ref: 'Bar' };
+      const getAttArn = { 'Fn::GetAtt': ['Bar', 'Arn'] };
+
+      const genStateMachine = (id, stateMachineArn) => ({
+        id,
+        definition: {
+          QueryLanguage: 'JSONata',
+          StartAt: 'A',
+          States: {
+            A: {
+              Type: 'Task',
+              Resource: 'arn:aws:states:::states:startExecution.sync:2',
+              Arguments: {
+                StateMachineArn: stateMachineArn,
+                Input: {},
+              },
+              End: true,
+            },
+          },
+        },
+      });
+
+      serverless.service.stepFunctions = {
+        stateMachines: {
+          myStateMachine1: genStateMachine('StateMachine1', refArn),
+          myStateMachine2: genStateMachine('StateMachine2', getAttArn),
+        },
+      };
+
+      serverlessStepFunctions.compileIamRole();
+      const resources = serverlessStepFunctions.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources;
+
+      const policy1 = resources.StateMachine1Role.Properties.Policies[0].PolicyDocument;
+      const statements1 = policy1.Statement;
+      const stateMachinePerms1 = statements1.filter(s => _.isEqual(s.Action, ['states:StartExecution']));
+      expect(stateMachinePerms1).to.have.lengthOf(1);
+      expect(stateMachinePerms1[0].Resource).to.deep.eq([refArn]);
+
+      const policy2 = resources.StateMachine2Role.Properties.Policies[0].PolicyDocument;
+      const statements2 = policy2.Statement;
+      const stateMachinePerms2 = statements2.filter(s => _.isEqual(s.Action, ['states:StartExecution']));
+      expect(stateMachinePerms2).to.have.lengthOf(1);
+      expect(stateMachinePerms2[0].Resource).to.deep.eq([getAttArn]);
+    });
+
     it('should handle ${AWS::Partition} in resource ARN', () => {
       const stateMachineArn = 'arn:aws:states:us-east-1:123456789:stateMachine:HelloStateMachine';
       const genStateMachine = id => ({


### PR DESCRIPTION
## Summary

- Fixes a `TypeError: state.Arguments.StateMachineArn.trim is not a function` crash when `StateMachineArn` in a JSONata `Arguments` block is an intrinsic function object (`!Ref`, `!GetAtt`) rather than a plain string
- Guard the `.trim()` call with a `typeof` string check; non-string values are passed through as-is to the IAM policy resource

## Test plan

- [x] Added test covering both `Ref` and `Fn::GetAtt` as `StateMachineArn` in JSONata `Arguments` — verifies the correct ARN object is used as the IAM resource
- [x] All 104 existing IAM role tests continue to pass

Fixes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)