### PR TITLE
fix: handle CloudFormation intrinsic functions in Arguments.StateMachineArn

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -449,9 +449,12 @@ function getStateMachineArn(state) {
   let stateMachineArn;
 
   if (state.Arguments) {
-    stateMachineArn = state.Arguments.StateMachineArn.trim().startsWith('{%')
-      ? '*'
-      : state.Arguments.StateMachineArn;
+    const arn = state.Arguments.StateMachineArn;
+    if (typeof arn !== 'string') {
+      stateMachineArn = arn;
+    } else {
+      stateMachineArn = arn.trim().startsWith('{%') ? '*' : arn;
+    }
   } else {
     stateMachineArn = state.Parameters['StateMachineArn.$']
       ? '*'

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -3312,6 +3312,49 @@ describe('#compileIamRole', () => {
       }]);
     });
 
+    it('jsonata with CloudFormation intrinsic StateMachineArn', () => {
+      const stateMachineArn = {
+        'Fn::Sub': 'arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:HelloStateMachine',
+      };
+      const genStateMachine = id => ({
+        id,
+        definition: {
+          QueryLanguage: 'JSONata',
+          StartAt: 'A',
+          States: {
+            A: {
+              Type: 'Task',
+              Resource: 'arn:aws:states:::states:startExecution.sync:2',
+              Arguments: {
+                StateMachineArn: stateMachineArn,
+                Input: {},
+              },
+              End: true,
+            },
+          },
+        },
+      });
+
+      serverless.service.stepFunctions = {
+        stateMachines: {
+          myStateMachine1: genStateMachine('StateMachine1'),
+        },
+      };
+
+      serverlessStepFunctions.compileIamRole();
+      const statements = serverlessStepFunctions.serverless.service
+        .provider.compiledCloudFormationTemplate.Resources.StateMachine1Role
+        .Properties.Policies[0].PolicyDocument.Statement;
+
+      const stateMachinePermissions = statements.filter(s => _.isEqual(s.Action, ['states:StartExecution']));
+      expect(stateMachinePermissions).to.have.lengthOf(1);
+      expect(stateMachinePermissions[0].Resource).to.deep.eq([stateMachineArn]);
+
+      const executionPermissions = statements.filter(s => _.isEqual(s.Action, ['states:DescribeExecution', 'states:StopExecution']));
+      expect(executionPermissions).to.have.lengthOf(1);
+      expect(executionPermissions[0].Resource).to.equal('*');
+    });
+
     it('should handle ${AWS::Partition} in resource ARN', () => {
       const stateMachineArn = 'arn:aws:states:us-east-1:123456789:stateMachine:HelloStateMachine';
       const genStateMachine = id => ({


### PR DESCRIPTION
Fixes #704

## Summary

- When using JSONata `QueryLanguage` with a CloudFormation intrinsic function (e.g. `!Sub` or `Fn::Sub`) as `StateMachineArn` in `Arguments`, `getStateMachineArn()` crashes with `TypeError: state.Arguments.StateMachineArn.trim is not a function` because it assumes the value is a string, but intrinsic functions resolve to objects like `{"Fn::Sub": "..."}`.
- Added a type check before calling `.trim()` — when `StateMachineArn` is not a string (i.e. a CloudFormation intrinsic), return it as-is for use in the IAM policy resource. This matches the existing behavior for `Parameters.StateMachineArn` which already handles intrinsics correctly.

## Reproduction

```yaml
# serverless.yml — this crashes on deploy
stepFunctions:
  stateMachines:
    Workflow:
      definition:
        States:
          InvokeChild:
            Type: Task
            Resource: 'arn:aws:states:::states:startExecution.sync:2'
            QueryLanguage: JSONata
            Arguments:
              StateMachineArn: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:ChildMachine"
              Input:
                key: "{% $states.input.value %}"
            End: true
```

```
TypeError: state.Arguments.StateMachineArn.trim is not a function
    at getStateMachineArn (compileIamRole.js:452:55)
```

## Changes

- `lib/deploy/stepFunctions/compileIamRole.js`: Check `typeof arn !== 'string'` before calling `.trim()` in `getStateMachineArn()`
- `lib/deploy/stepFunctions/compileIamRole.test.js`: Added test case for JSONata with CloudFormation intrinsic `StateMachineArn`

## Test plan

- [x] All 104 existing tests pass
- [x] New test case verifies `Fn::Sub` object is passed through correctly as the IAM policy resource