### PR TITLE
feat: support JSONata for EventBridge Scheduler IAM permissions

### DIFF
--- a/lib/deploy/stepFunctions/compileIamRole.js
+++ b/lib/deploy/stepFunctions/compileIamRole.js
@@ -659,8 +659,9 @@ function getHttpInvokePermissions(state) {
 }
 
 function getEventBridgeSchedulerPermissions(action, state) {
-  const scheduleGroupName = state.Parameters.GroupName || 'default';
-  const scheduleTargetRoleArn = state.Parameters.Target && state.Parameters.Target.RoleArn;
+  const scheduleGroupName = getParameterOrArgument(state, 'GroupName') || 'default';
+  const target = getParameterOrArgument(state, 'Target');
+  const scheduleTargetRoleArn = target && target.RoleArn;
 
   return [
     {

--- a/lib/deploy/stepFunctions/compileIamRole.test.js
+++ b/lib/deploy/stepFunctions/compileIamRole.test.js
@@ -4561,6 +4561,63 @@ describe('#compileIamRole', () => {
     expect(rolePermissions[0].Resource).to.deep.eq(['arn:aws:iam::${AWS::AccountId}:role/MyIAMRole']);
   });
 
+  it('should give event bridge scheduler createSchedule and passRole permissions (JSONata)', () => {
+    const genStateMachine = id => ({
+      id,
+      definition: {
+        StartAt: 'A',
+        QueryLanguage: 'JSONata',
+        States: {
+          A: {
+            Type: 'Task',
+            Resource: 'arn:aws:states:::aws-sdk:scheduler:createSchedule',
+            Arguments: {
+              ActionAfterCompletion: 'DELETE',
+              FlexibleTimeWindow: {
+                Mode: 'FLEXIBLE',
+                MaximumWindowInMinutes: 5,
+              },
+              Name: '{% $states.context.Execution.Name %}',
+              GroupName: 'MyScheduleGroup',
+              ScheduleExpression: 'at("2024-03-04T00:00:00")',
+              Target: {
+                Arn: 'arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:MyStateMachine',
+                RoleArn: 'arn:aws:iam::${AWS::AccountId}:role/MyIAMRole',
+                Input: {
+                  foo: 'bar',
+                },
+              },
+            },
+            End: true,
+          },
+        },
+      },
+    });
+
+    serverless.service.stepFunctions = {
+      stateMachines: {
+        myStateMachine1: genStateMachine('StateMachine1'),
+      },
+    };
+
+    serverlessStepFunctions.compileIamRole();
+    const statements = serverlessStepFunctions.serverless.service
+      .provider.compiledCloudFormationTemplate.Resources.StateMachine1Role
+      .Properties.Policies[0].PolicyDocument.Statement;
+
+    const schedulerPermissions = statements.filter(s => _.isEqual(s.Action, ['scheduler:CreateSchedule']));
+    expect(schedulerPermissions[0].Resource).to.has.lengthOf(1);
+    expect(schedulerPermissions[0].Resource).to.deep.eq([{
+      'Fn::Sub': [
+        'arn:${AWS::Partition}:scheduler:${AWS::Region}:${AWS::AccountId}:schedule/${scheduleGroupName}/*',
+        { scheduleGroupName: 'MyScheduleGroup' },
+      ],
+    }]);
+    const rolePermissions = statements.filter(s => _.isEqual(s.Action, ['iam:PassRole']));
+    expect(rolePermissions[0].Resource).to.has.lengthOf(1);
+    expect(rolePermissions[0].Resource).to.deep.eq(['arn:aws:iam::${AWS::AccountId}:role/MyIAMRole']);
+  });
+
   it('should give event bridge scheduler deleteSchedule permissions', () => {
     const genStateMachine = id => ({
       id,


### PR DESCRIPTION
### Summary
This PR adds JSONata support for EventBridge Scheduler IAM permission generation in Step Functions task states.

Previously, scheduler permissions were read only from Parameters, which caused IAM generation to fail for states using QueryLanguage: JSONata with Arguments.
Now the permission compiler resolves scheduler fields through the shared parameter/argument helper, so both JSONPath and JSONata definitions are supported.

### Changes

- Updated EventBridge Scheduler IAM permission extraction to support:
  - JSONPath (Parameters)
  - JSONata (Arguments)
- Added test coverage for the JSONata scheduler scenario.
- Preserved existing JSONPath behavior.