### PR TITLE
fix(iam): handle missing Parameters block when StateMachineArn is a top-level Ref

### DIFF
--- a/lib/deploy/stepFunctions/iamStrategies/stepFunctions.test.js
+++ b/lib/deploy/stepFunctions/iamStrategies/stepFunctions.test.js
@@ -122,6 +122,32 @@ describe('stepFunctions strategy', () => {
       });
     });
 
+    it('should not throw when StateMachineArn is a top-level Ref (no Parameters block)', () => {
+      const state = {
+        Type: 'Task',
+        Resource: 'arn:aws:states:::states:startExecution',
+        StateMachineArn: { Ref: 'goodbyeMachine' },
+      };
+      expect(() => getStartExecutionPermissions(state)).to.not.throw();
+      const result = getStartExecutionPermissions(state);
+      const startPerm = result.find(p => p.action === 'states:StartExecution');
+      expect(startPerm.resource).to.deep.equal({ Ref: 'goodbyeMachine' });
+    });
+
+    it('should not produce null resource when StateMachineArn is Fn::GetAtt in Parameters', () => {
+      const state = {
+        Type: 'Task',
+        Resource: 'arn:aws:states:::states:startExecution',
+        Parameters: {
+          StateMachineArn: { 'Fn::GetAtt': ['TestMachine', 'Arn'] },
+          Input: {},
+        },
+      };
+      const result = getStartExecutionPermissions(state);
+      const startPerm = result.find(p => p.action === 'states:StartExecution');
+      expect(startPerm.resource).to.deep.equal({ 'Fn::GetAtt': ['TestMachine', 'Arn'] });
+    });
+
     it('should use DISTRIBUTED mode stateMachineName for resource ARN', () => {
       const state = {
         Type: 'Map',

--- a/lib/deploy/stepFunctions/iamStrategies/utils.js
+++ b/lib/deploy/stepFunctions/iamStrategies/utils.js
@@ -116,10 +116,13 @@ function getStateMachineArn(state) {
     } else {
       stateMachineArn = arn.trim().startsWith('{%') ? '*' : arn;
     }
-  } else {
+  } else if (state.Parameters) {
     stateMachineArn = state.Parameters['StateMachineArn.$']
       ? '*'
       : state.Parameters.StateMachineArn;
+  } else {
+    // StateMachineArn may be a top-level field (e.g., { Ref: 'logicalId' })
+    stateMachineArn = state.StateMachineArn || '*';
   }
 
   return stateMachineArn;


### PR DESCRIPTION
## Summary

- Fixes a `TypeError: Cannot read properties of undefined (reading 'StateMachineArn.$')` crash in `getStateMachineArn` when a nested state machine is referenced via a top-level `Ref: logicalId` field (no `Parameters` block)
- The guard was missing: the `else` branch assumed `state.Parameters` always exists, but ASL allows `StateMachineArn` as a top-level field
- Falls back to `state.StateMachineArn` (e.g. `{ Ref: 'goodbyeMachine' }`) or `'*'` when neither `Parameters` nor `Arguments` is present

## Test plan

- [ ] New test: `should not throw when StateMachineArn is a top-level Ref (no Parameters block)` — confirms no TypeError and resource is the Ref object
- [ ] New test: `should not produce null resource when StateMachineArn is Fn::GetAtt in Parameters` — confirms intrinsic refs in Parameters pass through correctly
- [ ] Full test suite: `npm test` — 499 passing

Closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)