### PR TITLE
fix(iam): apply provider.rolePermissionsBoundary to ApigatewayToStepFunctionsRole

### DIFF
--- a/lib/deploy/events/apiGateway/iamRole.js
+++ b/lib/deploy/events/apiGateway/iamRole.js
@@ -61,6 +61,11 @@ module.exports = {
       },
     };
 
+    const permissionsBoundary = _.get(this.serverless.service, 'provider.rolePermissionsBoundary');
+    if (permissionsBoundary) {
+      iamRoleApiGatewayToStepFunctions.Properties.PermissionsBoundary = permissionsBoundary;
+    }
+
     const rolePath = _.get(this.serverless.service, 'provider.iam.role.path');
     if (rolePath) {
       iamRoleApiGatewayToStepFunctions.Properties.Path = rolePath;

--- a/lib/deploy/events/apiGateway/iamRole.test.js
+++ b/lib/deploy/events/apiGateway/iamRole.test.js
@@ -177,6 +177,27 @@ describe('#compileHttpIamRole()', () => {
       });
   });
 
+  it('should apply provider.rolePermissionsBoundary to API Gateway IAM role', () => {
+    serverlessStepFunctions.pluginhttpValidated = {
+      events: [
+        {
+          stateMachineName: 'first',
+          http: {
+            path: 'foo/bar1',
+            method: 'post',
+          },
+        },
+      ],
+    };
+    serverless.service.provider.rolePermissionsBoundary = 'arn:aws:iam::123456789:policy/DeveloperBoundaryPolicy';
+
+    return serverlessStepFunctions.compileHttpIamRole().then(() => {
+      const properties = serverlessStepFunctions.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources.ApigatewayToStepFunctionsRole.Properties;
+      expect(properties.PermissionsBoundary).to.equal('arn:aws:iam::123456789:policy/DeveloperBoundaryPolicy');
+    });
+  });
+
   it('should apply provider.iam.role.path to API Gateway IAM role', () => {
     serverlessStepFunctions.pluginhttpValidated = {
       events: [

--- a/lib/deploy/stepFunctions/iamStrategies/stepFunctions.test.js
+++ b/lib/deploy/stepFunctions/iamStrategies/stepFunctions.test.js
@@ -130,7 +130,7 @@ describe('stepFunctions strategy', () => {
       };
       expect(() => getStartExecutionPermissions(state)).to.not.throw();
       const result = getStartExecutionPermissions(state);
-      const startPerm = result.find(p => p.action === 'states:StartExecution');
+      const startPerm = result.find((p) => p.action === 'states:StartExecution');
       expect(startPerm.resource).to.deep.equal({ Ref: 'goodbyeMachine' });
     });
 
@@ -144,7 +144,7 @@ describe('stepFunctions strategy', () => {
         },
       };
       const result = getStartExecutionPermissions(state);
-      const startPerm = result.find(p => p.action === 'states:StartExecution');
+      const startPerm = result.find((p) => p.action === 'states:StartExecution');
       expect(startPerm.resource).to.deep.equal({ 'Fn::GetAtt': ['TestMachine', 'Arn'] });
     });
 

--- a/lib/invoke/invoke.test.js
+++ b/lib/invoke/invoke.test.js
@@ -419,7 +419,7 @@ describe('invoke', () => {
       return serverlessStepFunctions.invoke().then(() => {
         expect(stdoutStub.called).to.be.equal(false);
         expect(stderrStub.called).to.be.equal(true);
-        const written = stderrStub.args.find(args => args[0].includes('"FAILED"'));
+        const written = stderrStub.args.find((args) => args[0].includes('"FAILED"'));
         expect(written).to.not.equal(undefined);
         expect(process.exitCode).to.equal(1);
       });


### PR DESCRIPTION
## Summary

- The auto-generated `ApigatewayToStepFunctionsRole` did not inherit `provider.rolePermissionsBoundary`, causing `iam:CreateRole` to fail in environments that enforce a permissions boundary policy
- The state machine execution role (`compileIamRole.js`) already handled this correctly; this brings `apiGateway/iamRole.js` in line with the same behaviour
- Mirrors the existing `provider.iam.role.path` pattern already present in the same file

## Test plan

- [ ] New test: `should apply provider.rolePermissionsBoundary to API Gateway IAM role` — confirms `PermissionsBoundary` is set on the generated role
- [ ] Full test suite: `npm test` — 498 passing

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)