### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## What
+
+<!-- A short description of the change. -->
+
+## Why
+
+<!-- The motivation or problem being solved. Link the related issue: -->
+
+Closes #
+
+## Test plan
+
+- [ ] Tests added or updated to cover the change
+- [ ] `npm test` passes locally


### PR DESCRIPTION
## What

Adds `.github/pull_request_template.md` — GitHub will pre-fill the PR body with this template whenever a contributor opens a new PR.

## Why

Several PRs have been submitted with no description and no tests (#658, #644), requiring maintainers to chase contributors for basic context before review can begin.

Closes #722

## Test plan

- [ ] No code changes — template file only