### PR TITLE
refactor(naming): introduce generateLogicalId factory method

### DIFF
--- a/lib/naming.js
+++ b/lib/naming.js
@@ -1,36 +1,32 @@
 'use strict';
 
 module.exports = {
+  generateLogicalId(name, suffix = '') {
+    return `${this.provider.naming.getNormalizedFunctionName(name)}${suffix}`;
+  },
+
   getStateMachineLogicalId(stateMachineName, stateMachine) {
     const custom = stateMachine ? stateMachine.id || stateMachine.name : null;
-
     if (custom) {
-      return `${this.provider.naming.getNormalizedFunctionName(custom)}`;
+      return this.generateLogicalId(custom);
     }
-
-    return `${this.provider.naming
-      .getNormalizedFunctionName(stateMachineName)}StepFunctionsStateMachine`;
+    return this.generateLogicalId(stateMachineName, 'StepFunctionsStateMachine');
   },
 
   getStateMachineOutputLogicalId(stateMachineName, stateMachine) {
     const custom = stateMachine ? stateMachine.id || stateMachine.name : null;
-
     if (custom) {
-      return `${this.provider.naming.getNormalizedFunctionName(custom)}Arn`;
+      return this.generateLogicalId(custom, 'Arn');
     }
-
-    return `${this.provider.naming
-      .getNormalizedFunctionName(stateMachineName)}StepFunctionsStateMachineArn`;
+    return this.generateLogicalId(stateMachineName, 'StepFunctionsStateMachineArn');
   },
 
   getActivityLogicalId(activityName) {
-    return `${this.provider.naming
-      .getNormalizedFunctionName(activityName)}StepFunctionsActivity`;
+    return this.generateLogicalId(activityName, 'StepFunctionsActivity');
   },
 
   getActivityOutputLogicalId(activityName) {
-    return `${this.provider.naming
-      .getNormalizedFunctionName(activityName)}StepFunctionsActivityArn`;
+    return this.generateLogicalId(activityName, 'StepFunctionsActivityArn');
   },
 
   getStateMachinePolicyName() {
@@ -59,20 +55,15 @@ module.exports = {
   },
 
   getScheduleLogicalId(stateMachineName, scheduleIndex) {
-    return `${this.provider.naming
-      .getNormalizedFunctionName(stateMachineName)}StepFunctionsEventsRuleSchedule${scheduleIndex}`;
+    return this.generateLogicalId(stateMachineName, `StepFunctionsEventsRuleSchedule${scheduleIndex}`);
   },
 
   getSchedulerScheduleLogicalId(stateMachineName, scheduleIndex) {
-    return `${this.provider.naming.getNormalizedFunctionName(
-      stateMachineName,
-    )}StepFunctionsSchedulerSchedule${scheduleIndex}`;
+    return this.generateLogicalId(stateMachineName, `StepFunctionsSchedulerSchedule${scheduleIndex}`);
   },
 
   getScheduleToStepFunctionsIamRoleLogicalId(stateMachineName) {
-    return `${this.provider.naming.getNormalizedFunctionName(
-      stateMachineName,
-    )}ScheduleToStepFunctionsRole`;
+    return this.generateLogicalId(stateMachineName, 'ScheduleToStepFunctionsRole');
   },
 
   getSchedulePolicyName(stateMachineName) {
@@ -91,8 +82,7 @@ module.exports = {
   },
 
   getCloudWatchEventLogicalId(stateMachineName, cloudWatchIndex) {
-    return `${this.provider.naming
-      .getNormalizedFunctionName(stateMachineName)}EventsRuleCloudWatchEvent${cloudWatchIndex}`;
+    return this.generateLogicalId(stateMachineName, `EventsRuleCloudWatchEvent${cloudWatchIndex}`);
   },
 
   getCloudWatchEventPolicyName(stateMachineName) {
@@ -106,8 +96,6 @@ module.exports = {
   },
 
   getCloudWatchEventToStepFunctionsIamRoleLogicalId(stateMachineName) {
-    return `${this.provider.naming.getNormalizedFunctionName(
-      stateMachineName,
-    )}EventToStepFunctionsRole`;
+    return this.generateLogicalId(stateMachineName, 'EventToStepFunctionsRole');
   },
 };

--- a/lib/naming.test.js
+++ b/lib/naming.test.js
@@ -16,6 +16,18 @@ describe('#naming', () => {
     serverlessStepFunctions = new ServerlessStepFunctions(serverless);
   });
 
+  describe('#generateLogicalId()', () => {
+    it('should normalize the name and append the suffix', () => {
+      expect(serverlessStepFunctions.generateLogicalId('myResource', 'StepFunctionsFoo')).to
+        .equal('MyResourceStepFunctionsFoo');
+    });
+
+    it('should normalize the name with no suffix', () => {
+      expect(serverlessStepFunctions.generateLogicalId('myResource')).to
+        .equal('MyResource');
+    });
+  });
+
   describe('#getStateMachineLogicalId()', () => {
     it('should normalize the stateMachine name and add the standard suffix', () => {
       expect(serverlessStepFunctions.getStateMachineLogicalId('stateMachine')).to


### PR DESCRIPTION
Closes #758

## Summary
- Add `generateLogicalId(name, suffix)` factory to `lib/naming.js`, centralising the repeated `getNormalizedFunctionName(name) + suffix` pattern
- Refactor 9 `get*LogicalId()` methods to delegate to the factory — public API unchanged, no callers affected
- Add 2 tests covering the factory with and without a suffix

## Test plan
- [ ] All 19 naming tests pass
- [ ] Full suite (548 tests) passes
- [ ] No callers of `get*LogicalId()` methods require changes

Part of #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)