### PR TITLE
refactor(notifications): split compileNotifications into Strategy pattern

### DIFF
--- a/lib/deploy/stepFunctions/compileNotifications.js
+++ b/lib/deploy/stepFunctions/compileNotifications.js
@@ -6,33 +6,12 @@ const BbPromise = require('bluebird');
 const schema = require('./compileNotifications.schema');
 const logger = require('../../utils/logger');
 const { translateLocalFunctionNames } = require('../../utils/aws');
+const { getStrategy } = require('./notificationStrategies');
+const { generatePolicyName } = require('./notificationStrategies/utils');
 
 const executionStatuses = [
   'ABORTED', 'FAILED', 'RUNNING', 'SUCCEEDED', 'TIMED_OUT',
 ];
-
-const supportedTargets = [
-  'sns', 'sqs', 'kinesis', 'firehose', 'lambda', 'stepFunctions',
-];
-
-const targetPermissions = {
-  sns: 'sns:Publish',
-  sqs: 'sqs:SendMessage',
-  kinesis: 'kinesis:PutRecord',
-  firehose: 'firehose:PutRecord',
-  lambda: 'lambda:InvokeFunction',
-  stepFunctions: 'states:StartExecution',
-};
-
-function generateTargetId(target, index, stateMachineName, status) {
-  const suffix = crypto
-    .createHash('md5')
-    .update(JSON.stringify({ target, index }))
-    .digest('hex')
-    .substr(0, 5);
-
-  return `${stateMachineName}-${status}-${suffix}`;
-}
 
 function generateLogicalId(prefix, index, resource) {
   const suffix = crypto
@@ -41,178 +20,6 @@ function generateLogicalId(prefix, index, resource) {
     .digest('hex')
     .substr(0, 5);
   return `${prefix}${suffix}`;
-}
-
-function generatePolicyName(status, targetType, action, resource) {
-  const suffix = crypto
-    .createHash('md5')
-    .update(JSON.stringify({ action, resource }))
-    .digest('hex')
-    .substr(0, 5);
-  return `${status}-${targetType}-${suffix}`;
-}
-
-function compileTarget(stateMachineName, status, targetObj, targetIndex, iamRoleLogicalId) {
-  const inputOptions = {
-    ...(targetObj.inputPath && { InputPath: targetObj.inputPath }),
-    ...(targetObj.inputTransformer && {
-      InputTransformer: {
-        InputPathsMap: targetObj.inputTransformer.inputPathsMap,
-        InputTemplate: targetObj.inputTransformer.inputTemplate,
-      },
-    }),
-  };
-
-  // SQS and Kinesis are special cases as they can have additional props
-  if (_.has(targetObj, 'sqs.arn')) {
-    const Arn = targetObj.sqs.arn;
-    return {
-      Arn,
-      Id: generateTargetId({ Arn }, targetIndex, stateMachineName, status),
-      SqsParameters: { MessageGroupId: targetObj.sqs.messageGroupId },
-      ...inputOptions,
-    };
-  }
-  if (_.has(targetObj, 'kinesis.arn')) {
-    const Arn = targetObj.kinesis.arn;
-    return {
-      Arn,
-      Id: generateTargetId({ Arn }, targetIndex, stateMachineName, status),
-      KinesisParameters: { PartitionKeyPath: targetObj.kinesis.partitionKeyPath },
-      ...inputOptions,
-    };
-  }
-  if (_.has(targetObj, 'stepFunctions')) {
-    const Arn = targetObj.stepFunctions;
-    return {
-      Arn,
-      Id: generateTargetId({ Arn }, targetIndex, stateMachineName, status),
-      RoleArn: { 'Fn::GetAtt': [iamRoleLogicalId, 'Arn'] },
-      ...inputOptions,
-    };
-  }
-
-  const targetType = supportedTargets.find((t) => _.has(targetObj, t));
-  const Arn = _.get(targetObj, targetType);
-  return {
-    Arn,
-    Id: generateTargetId({ Arn }, targetIndex, stateMachineName, status),
-    ...inputOptions,
-  };
-}
-
-function compileSnsPolicy(status, snsTarget) {
-  return {
-    Type: 'AWS::SNS::TopicPolicy',
-    Properties: {
-      PolicyDocument: {
-        Version: '2012-10-17',
-        Statement: {
-          Sid: generatePolicyName(status, 'sns', 'sns:Publish', snsTarget),
-          Principal: {
-            Service: 'events.amazonaws.com',
-          },
-          Effect: 'Allow',
-          Action: 'sns:Publish',
-          Resource: snsTarget,
-        },
-      },
-      Topics: [snsTarget],
-    },
-  };
-}
-
-function convertToQueueUrl(sqsArn) {
-  if (_.isString(sqsArn)) {
-    const segments = sqsArn.split(':');
-    const queueName = _.last(segments);
-    return {
-      'Fn::Sub': [
-        'https://sqs.${AWS::Region}.amazonaws.com/${AWS::AccountId}/${QueueName}',
-        { QueueName: queueName },
-      ],
-    };
-  }
-  if (sqsArn['Fn::GetAtt']) {
-    const logicalId = sqsArn['Fn::GetAtt'][0];
-    return { Ref: logicalId };
-  }
-  throw new Error(
-    `Unable to convert SQS ARN [${sqsArn}] to SQS Url. `
-    + 'This is required for setting up Step Functions notifications to SQS. '
-    + 'Try using Fn::GetAtt when setting the SQS arn.',
-  );
-}
-
-function compileSqsPolicy(status, sqsTarget) {
-  return {
-    Type: 'AWS::SQS::QueuePolicy',
-    Properties: {
-      PolicyDocument: {
-        Version: '2012-10-17',
-        Statement: {
-          Sid: generatePolicyName(status, 'sqs', 'sqs:SendMessage', sqsTarget),
-          Principal: {
-            Service: 'events.amazonaws.com',
-          },
-          Effect: 'Allow',
-          Action: 'sqs:SendMessage',
-          Resource: sqsTarget,
-        },
-      },
-      Queues: [convertToQueueUrl(sqsTarget)],
-    },
-  };
-}
-
-function compileLambdaPermission(lambdaTarget) {
-  return {
-    Type: 'AWS::Lambda::Permission',
-    Properties: {
-      Action: 'lambda:InvokeFunction',
-      FunctionName: lambdaTarget,
-      Principal: 'events.amazonaws.com',
-    },
-  };
-}
-
-function compilePermissionForTarget(status, targetObj) {
-  if (targetObj.sns) {
-    return {
-      type: 'policy',
-      resource: compileSnsPolicy(status, targetObj.sns),
-    };
-  }
-  if (targetObj.sqs) {
-    const arn = _.get(targetObj, 'sqs.arn', targetObj.sqs);
-    return {
-      type: 'policy',
-      resource: compileSqsPolicy(status, arn),
-    };
-  }
-  if (targetObj.kinesis) {
-    const arn = _.get(targetObj, 'kinesis.arn', targetObj.kinesis);
-    return {
-      type: 'iam',
-      action: 'kinesis:PutRecord',
-      resource: arn,
-    };
-  }
-  if (targetObj.lambda) {
-    return {
-      type: 'policy',
-      resource: compileLambdaPermission(targetObj.lambda),
-    };
-  }
-
-  const targetType = supportedTargets.find((t) => _.has(targetObj, t));
-  const action = targetPermissions[targetType];
-
-  return {
-    type: 'iam',
-    action,
-    resource: targetObj[targetType],
-  };
 }
 
 function bootstrapIamRole(rolePath) {
@@ -254,11 +61,11 @@ function* compilePermissionResources(stateMachineLogicalId, iamRoleLogicalId, ta
 
   for (let index = 0; index < targets.length; index++) {
     const { status, target } = targets[index];
-    const perm = compilePermissionForTarget(status, target);
+    const { type, strategy } = getStrategy(target);
+    const perm = strategy.compilePermission(status, target);
     if (perm.type === 'iam') {
-      const targetType = _.keys(target)[0];
       addPolicy(
-        generatePolicyName(status, targetType, perm.action, perm.resource),
+        generatePolicyName(status, type, perm.action, perm.resource),
         perm.action,
         perm.resource,
       );
@@ -326,13 +133,10 @@ function* compileResources(
   for (const status of executionStatuses) {
     const targets = normalizedNotificationsObj[status];
     if (!_.isEmpty(targets)) {
-      const cfnTargets = targets.map((t, index) => compileTarget(
-        stateMachineName,
-        status,
-        t,
-        index,
-        iamRoleLogicalId,
-      ));
+      const cfnTargets = targets.map((t, index) => {
+        const { strategy } = getStrategy(t);
+        return strategy.compileTarget(t, index, stateMachineName, status, iamRoleLogicalId);
+      });
 
       const eventRuleLogicalId = `${stateMachineLogicalId}Notifications${status.replace('_', '')}EventRule`;
       const eventRule = {

--- a/lib/deploy/stepFunctions/notificationStrategies/firehose.js
+++ b/lib/deploy/stepFunctions/notificationStrategies/firehose.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const { generateTargetId, buildInputOptions } = require('./utils');
+
+function compileTarget(targetObj, index, stateMachineName, status) {
+  const Arn = targetObj.firehose;
+  return {
+    Arn,
+    Id: generateTargetId({ Arn }, index, stateMachineName, status),
+    ...buildInputOptions(targetObj),
+  };
+}
+
+function compilePermission(status, targetObj) {
+  return { type: 'iam', action: 'firehose:PutRecord', resource: targetObj.firehose };
+}
+
+module.exports = { compileTarget, compilePermission };

--- a/lib/deploy/stepFunctions/notificationStrategies/firehose.test.js
+++ b/lib/deploy/stepFunctions/notificationStrategies/firehose.test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const expect = require('chai').expect;
+const { compileTarget, compilePermission } = require('./firehose');
+
+describe('firehose notification strategy', () => {
+  describe('#compileTarget()', () => {
+    it('should return a CF target with the Firehose ARN', () => {
+      const targetObj = { firehose: 'arn:aws:firehose:us-east-1:123456789:deliverystream/MyStream' };
+      const result = compileTarget(targetObj, 0, 'MyMachine', 'FAILED');
+      expect(result.Arn).to.equal('arn:aws:firehose:us-east-1:123456789:deliverystream/MyStream');
+      expect(result.Id).to.be.a('string');
+    });
+  });
+
+  describe('#compilePermission()', () => {
+    it('should return an IAM permission for Firehose', () => {
+      const targetObj = { firehose: 'arn:aws:firehose:us-east-1:123456789:deliverystream/MyStream' };
+      const result = compilePermission('FAILED', targetObj);
+      expect(result).to.deep.equal({
+        type: 'iam',
+        action: 'firehose:PutRecord',
+        resource: 'arn:aws:firehose:us-east-1:123456789:deliverystream/MyStream',
+      });
+    });
+  });
+});

--- a/lib/deploy/stepFunctions/notificationStrategies/index.js
+++ b/lib/deploy/stepFunctions/notificationStrategies/index.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const sns = require('./sns');
+const sqs = require('./sqs');
+const kinesis = require('./kinesis');
+const firehose = require('./firehose');
+const lambda = require('./lambda');
+const stepFunctions = require('./stepFunctions');
+
+const registry = new Map([
+  ['sns', sns],
+  ['sqs', sqs],
+  ['kinesis', kinesis],
+  ['firehose', firehose],
+  ['lambda', lambda],
+  ['stepFunctions', stepFunctions],
+]);
+
+function getStrategy(targetObj) {
+  for (const [type, strategy] of registry) {
+    if (Object.hasOwn(targetObj, type)) {
+      return { type, strategy };
+    }
+  }
+  return null;
+}
+
+module.exports = { registry, getStrategy };

--- a/lib/deploy/stepFunctions/notificationStrategies/kinesis.js
+++ b/lib/deploy/stepFunctions/notificationStrategies/kinesis.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const _ = require('lodash');
+const { generateTargetId, buildInputOptions } = require('./utils');
+
+function compileTarget(targetObj, index, stateMachineName, status) {
+  const inputOptions = buildInputOptions(targetObj);
+  if (_.has(targetObj, 'kinesis.arn')) {
+    const Arn = targetObj.kinesis.arn;
+    return {
+      Arn,
+      Id: generateTargetId({ Arn }, index, stateMachineName, status),
+      KinesisParameters: { PartitionKeyPath: targetObj.kinesis.partitionKeyPath },
+      ...inputOptions,
+    };
+  }
+  const Arn = targetObj.kinesis;
+  return {
+    Arn,
+    Id: generateTargetId({ Arn }, index, stateMachineName, status),
+    ...inputOptions,
+  };
+}
+
+function compilePermission(status, targetObj) {
+  const arn = _.get(targetObj, 'kinesis.arn', targetObj.kinesis);
+  return { type: 'iam', action: 'kinesis:PutRecord', resource: arn };
+}
+
+module.exports = { compileTarget, compilePermission };

--- a/lib/deploy/stepFunctions/notificationStrategies/kinesis.test.js
+++ b/lib/deploy/stepFunctions/notificationStrategies/kinesis.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const expect = require('chai').expect;
+const { compileTarget, compilePermission } = require('./kinesis');
+
+describe('kinesis notification strategy', () => {
+  describe('#compileTarget()', () => {
+    it('should return a CF target with a plain Kinesis ARN', () => {
+      const targetObj = { kinesis: 'arn:aws:kinesis:us-east-1:123456789:stream/MyStream' };
+      const result = compileTarget(targetObj, 0, 'MyMachine', 'FAILED');
+      expect(result.Arn).to.equal('arn:aws:kinesis:us-east-1:123456789:stream/MyStream');
+      expect(result).to.not.have.property('KinesisParameters');
+    });
+
+    it('should return KinesisParameters when kinesis.arn is used', () => {
+      const targetObj = { kinesis: { arn: 'arn:aws:kinesis:us-east-1:123456789:stream/MyStream', partitionKeyPath: '$.id' } };
+      const result = compileTarget(targetObj, 0, 'MyMachine', 'FAILED');
+      expect(result.Arn).to.equal('arn:aws:kinesis:us-east-1:123456789:stream/MyStream');
+      expect(result.KinesisParameters).to.deep.equal({ PartitionKeyPath: '$.id' });
+    });
+  });
+
+  describe('#compilePermission()', () => {
+    it('should return an IAM permission for a plain Kinesis ARN', () => {
+      const targetObj = { kinesis: 'arn:aws:kinesis:us-east-1:123456789:stream/MyStream' };
+      const result = compilePermission('FAILED', targetObj);
+      expect(result).to.deep.equal({
+        type: 'iam',
+        action: 'kinesis:PutRecord',
+        resource: 'arn:aws:kinesis:us-east-1:123456789:stream/MyStream',
+      });
+    });
+
+    it('should return an IAM permission using nested kinesis.arn', () => {
+      const targetObj = { kinesis: { arn: 'arn:aws:kinesis:us-east-1:123456789:stream/MyStream', partitionKeyPath: '$.id' } };
+      const result = compilePermission('FAILED', targetObj);
+      expect(result).to.deep.equal({
+        type: 'iam',
+        action: 'kinesis:PutRecord',
+        resource: 'arn:aws:kinesis:us-east-1:123456789:stream/MyStream',
+      });
+    });
+  });
+});

--- a/lib/deploy/stepFunctions/notificationStrategies/lambda.js
+++ b/lib/deploy/stepFunctions/notificationStrategies/lambda.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const { generateTargetId, buildInputOptions } = require('./utils');
+
+function compileTarget(targetObj, index, stateMachineName, status) {
+  const Arn = targetObj.lambda;
+  return {
+    Arn,
+    Id: generateTargetId({ Arn }, index, stateMachineName, status),
+    ...buildInputOptions(targetObj),
+  };
+}
+
+function compilePermission(status, targetObj) {
+  return {
+    type: 'policy',
+    resource: {
+      Type: 'AWS::Lambda::Permission',
+      Properties: {
+        Action: 'lambda:InvokeFunction',
+        FunctionName: targetObj.lambda,
+        Principal: 'events.amazonaws.com',
+      },
+    },
+  };
+}
+
+module.exports = { compileTarget, compilePermission };

--- a/lib/deploy/stepFunctions/notificationStrategies/lambda.test.js
+++ b/lib/deploy/stepFunctions/notificationStrategies/lambda.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const expect = require('chai').expect;
+const { compileTarget, compilePermission } = require('./lambda');
+
+describe('lambda notification strategy', () => {
+  describe('#compileTarget()', () => {
+    it('should return a CF target with the Lambda ARN', () => {
+      const targetObj = { lambda: 'arn:aws:lambda:us-east-1:123456789:function:MyFunction' };
+      const result = compileTarget(targetObj, 0, 'MyMachine', 'FAILED');
+      expect(result.Arn).to.equal('arn:aws:lambda:us-east-1:123456789:function:MyFunction');
+      expect(result.Id).to.be.a('string');
+    });
+  });
+
+  describe('#compilePermission()', () => {
+    it('should return a Lambda Permission resource', () => {
+      const targetObj = { lambda: 'arn:aws:lambda:us-east-1:123456789:function:MyFunction' };
+      const result = compilePermission('FAILED', targetObj);
+      expect(result.type).to.equal('policy');
+      expect(result.resource.Type).to.equal('AWS::Lambda::Permission');
+      expect(result.resource.Properties.FunctionName).to.equal('arn:aws:lambda:us-east-1:123456789:function:MyFunction');
+      expect(result.resource.Properties.Action).to.equal('lambda:InvokeFunction');
+    });
+  });
+});

--- a/lib/deploy/stepFunctions/notificationStrategies/sns.js
+++ b/lib/deploy/stepFunctions/notificationStrategies/sns.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const { generateTargetId, generatePolicyName, buildInputOptions } = require('./utils');
+
+function compileTarget(targetObj, index, stateMachineName, status) {
+  const Arn = targetObj.sns;
+  return {
+    Arn,
+    Id: generateTargetId({ Arn }, index, stateMachineName, status),
+    ...buildInputOptions(targetObj),
+  };
+}
+
+function compilePermission(status, targetObj) {
+  const snsTarget = targetObj.sns;
+  return {
+    type: 'policy',
+    resource: {
+      Type: 'AWS::SNS::TopicPolicy',
+      Properties: {
+        PolicyDocument: {
+          Version: '2012-10-17',
+          Statement: {
+            Sid: generatePolicyName(status, 'sns', 'sns:Publish', snsTarget),
+            Principal: { Service: 'events.amazonaws.com' },
+            Effect: 'Allow',
+            Action: 'sns:Publish',
+            Resource: snsTarget,
+          },
+        },
+        Topics: [snsTarget],
+      },
+    },
+  };
+}
+
+module.exports = { compileTarget, compilePermission };

--- a/lib/deploy/stepFunctions/notificationStrategies/sns.test.js
+++ b/lib/deploy/stepFunctions/notificationStrategies/sns.test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const expect = require('chai').expect;
+const { compileTarget, compilePermission } = require('./sns');
+
+describe('sns notification strategy', () => {
+  describe('#compileTarget()', () => {
+    it('should return a CF target with the SNS ARN', () => {
+      const targetObj = { sns: 'arn:aws:sns:us-east-1:123456789:MyTopic' };
+      const result = compileTarget(targetObj, 0, 'MyMachine', 'FAILED');
+      expect(result.Arn).to.equal('arn:aws:sns:us-east-1:123456789:MyTopic');
+      expect(result.Id).to.be.a('string');
+    });
+
+    it('should include InputPath when set', () => {
+      const targetObj = { sns: 'arn:aws:sns:us-east-1:123456789:MyTopic', inputPath: '$.detail' };
+      const result = compileTarget(targetObj, 0, 'MyMachine', 'FAILED');
+      expect(result.InputPath).to.equal('$.detail');
+    });
+  });
+
+  describe('#compilePermission()', () => {
+    it('should return a policy permission with AWS::SNS::TopicPolicy', () => {
+      const targetObj = { sns: 'arn:aws:sns:us-east-1:123456789:MyTopic' };
+      const result = compilePermission('FAILED', targetObj);
+      expect(result.type).to.equal('policy');
+      expect(result.resource.Type).to.equal('AWS::SNS::TopicPolicy');
+      expect(result.resource.Properties.Topics[0]).to.equal('arn:aws:sns:us-east-1:123456789:MyTopic');
+      expect(result.resource.Properties.PolicyDocument.Statement.Action).to.equal('sns:Publish');
+    });
+  });
+});

--- a/lib/deploy/stepFunctions/notificationStrategies/sqs.js
+++ b/lib/deploy/stepFunctions/notificationStrategies/sqs.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const _ = require('lodash');
+const { generateTargetId, generatePolicyName, buildInputOptions } = require('./utils');
+
+function convertToQueueUrl(sqsArn) {
+  if (_.isString(sqsArn)) {
+    const segments = sqsArn.split(':');
+    const queueName = _.last(segments);
+    return {
+      'Fn::Sub': [
+        'https://sqs.${AWS::Region}.amazonaws.com/${AWS::AccountId}/${QueueName}',
+        { QueueName: queueName },
+      ],
+    };
+  }
+  if (sqsArn['Fn::GetAtt']) {
+    const logicalId = sqsArn['Fn::GetAtt'][0];
+    return { Ref: logicalId };
+  }
+  throw new Error(
+    `Unable to convert SQS ARN [${sqsArn}] to SQS Url. `
+    + 'This is required for setting up Step Functions notifications to SQS. '
+    + 'Try using Fn::GetAtt when setting the SQS arn.',
+  );
+}
+
+function compileTarget(targetObj, index, stateMachineName, status) {
+  const inputOptions = buildInputOptions(targetObj);
+  if (_.has(targetObj, 'sqs.arn')) {
+    const Arn = targetObj.sqs.arn;
+    return {
+      Arn,
+      Id: generateTargetId({ Arn }, index, stateMachineName, status),
+      SqsParameters: { MessageGroupId: targetObj.sqs.messageGroupId },
+      ...inputOptions,
+    };
+  }
+  const Arn = targetObj.sqs;
+  return {
+    Arn,
+    Id: generateTargetId({ Arn }, index, stateMachineName, status),
+    ...inputOptions,
+  };
+}
+
+function compilePermission(status, targetObj) {
+  const arn = _.get(targetObj, 'sqs.arn', targetObj.sqs);
+  return {
+    type: 'policy',
+    resource: {
+      Type: 'AWS::SQS::QueuePolicy',
+      Properties: {
+        PolicyDocument: {
+          Version: '2012-10-17',
+          Statement: {
+            Sid: generatePolicyName(status, 'sqs', 'sqs:SendMessage', arn),
+            Principal: { Service: 'events.amazonaws.com' },
+            Effect: 'Allow',
+            Action: 'sqs:SendMessage',
+            Resource: arn,
+          },
+        },
+        Queues: [convertToQueueUrl(arn)],
+      },
+    },
+  };
+}
+
+module.exports = { compileTarget, compilePermission, convertToQueueUrl };

--- a/lib/deploy/stepFunctions/notificationStrategies/sqs.test.js
+++ b/lib/deploy/stepFunctions/notificationStrategies/sqs.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const expect = require('chai').expect;
+const { compileTarget, compilePermission } = require('./sqs');
+
+describe('sqs notification strategy', () => {
+  describe('#compileTarget()', () => {
+    it('should return a CF target with a plain SQS ARN', () => {
+      const targetObj = { sqs: 'arn:aws:sqs:us-east-1:123456789:MyQueue' };
+      const result = compileTarget(targetObj, 0, 'MyMachine', 'FAILED');
+      expect(result.Arn).to.equal('arn:aws:sqs:us-east-1:123456789:MyQueue');
+      expect(result).to.not.have.property('SqsParameters');
+    });
+
+    it('should return SqsParameters when sqs.arn is used', () => {
+      const targetObj = { sqs: { arn: 'arn:aws:sqs:us-east-1:123456789:MyFifoQueue.fifo', messageGroupId: 'group1' } };
+      const result = compileTarget(targetObj, 0, 'MyMachine', 'FAILED');
+      expect(result.Arn).to.equal('arn:aws:sqs:us-east-1:123456789:MyFifoQueue.fifo');
+      expect(result.SqsParameters).to.deep.equal({ MessageGroupId: 'group1' });
+    });
+  });
+
+  describe('#compilePermission()', () => {
+    it('should return a policy permission with AWS::SQS::QueuePolicy for plain ARN', () => {
+      const targetObj = { sqs: 'arn:aws:sqs:us-east-1:123456789:MyQueue' };
+      const result = compilePermission('FAILED', targetObj);
+      expect(result.type).to.equal('policy');
+      expect(result.resource.Type).to.equal('AWS::SQS::QueuePolicy');
+      expect(result.resource.Properties.PolicyDocument.Statement.Action).to.equal('sqs:SendMessage');
+    });
+
+    it('should return a policy permission using nested sqs.arn', () => {
+      const targetObj = { sqs: { arn: 'arn:aws:sqs:us-east-1:123456789:MyQueue', messageGroupId: 'group1' } };
+      const result = compilePermission('FAILED', targetObj);
+      expect(result.type).to.equal('policy');
+      expect(result.resource.Type).to.equal('AWS::SQS::QueuePolicy');
+    });
+  });
+});

--- a/lib/deploy/stepFunctions/notificationStrategies/stepFunctions.js
+++ b/lib/deploy/stepFunctions/notificationStrategies/stepFunctions.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const { generateTargetId, buildInputOptions } = require('./utils');
+
+function compileTarget(targetObj, index, stateMachineName, status, iamRoleLogicalId) {
+  const Arn = targetObj.stepFunctions;
+  return {
+    Arn,
+    Id: generateTargetId({ Arn }, index, stateMachineName, status),
+    RoleArn: { 'Fn::GetAtt': [iamRoleLogicalId, 'Arn'] },
+    ...buildInputOptions(targetObj),
+  };
+}
+
+function compilePermission(status, targetObj) {
+  return { type: 'iam', action: 'states:StartExecution', resource: targetObj.stepFunctions };
+}
+
+module.exports = { compileTarget, compilePermission };

--- a/lib/deploy/stepFunctions/notificationStrategies/stepFunctions.test.js
+++ b/lib/deploy/stepFunctions/notificationStrategies/stepFunctions.test.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const expect = require('chai').expect;
+const { compileTarget, compilePermission } = require('./stepFunctions');
+
+describe('stepFunctions notification strategy', () => {
+  describe('#compileTarget()', () => {
+    it('should return a CF target with RoleArn', () => {
+      const targetObj = { stepFunctions: 'arn:aws:states:us-east-1:123456789:stateMachine:MyMachine' };
+      const result = compileTarget(targetObj, 0, 'MyMachine', 'FAILED', 'MyIamRoleLogicalId');
+      expect(result.Arn).to.equal('arn:aws:states:us-east-1:123456789:stateMachine:MyMachine');
+      expect(result.RoleArn).to.deep.equal({ 'Fn::GetAtt': ['MyIamRoleLogicalId', 'Arn'] });
+      expect(result.Id).to.be.a('string');
+    });
+  });
+
+  describe('#compilePermission()', () => {
+    it('should return an IAM permission for Step Functions execution', () => {
+      const targetObj = { stepFunctions: 'arn:aws:states:us-east-1:123456789:stateMachine:MyMachine' };
+      const result = compilePermission('FAILED', targetObj);
+      expect(result).to.deep.equal({
+        type: 'iam',
+        action: 'states:StartExecution',
+        resource: 'arn:aws:states:us-east-1:123456789:stateMachine:MyMachine',
+      });
+    });
+  });
+});

--- a/lib/deploy/stepFunctions/notificationStrategies/utils.js
+++ b/lib/deploy/stepFunctions/notificationStrategies/utils.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const crypto = require('node:crypto');
+
+function generateTargetId(target, index, stateMachineName, status) {
+  const suffix = crypto
+    .createHash('md5')
+    .update(JSON.stringify({ target, index }))
+    .digest('hex')
+    .substr(0, 5);
+  return `${stateMachineName}-${status}-${suffix}`;
+}
+
+function generatePolicyName(status, targetType, action, resource) {
+  const suffix = crypto
+    .createHash('md5')
+    .update(JSON.stringify({ action, resource }))
+    .digest('hex')
+    .substr(0, 5);
+  return `${status}-${targetType}-${suffix}`;
+}
+
+function buildInputOptions(targetObj) {
+  return {
+    ...(targetObj.inputPath && { InputPath: targetObj.inputPath }),
+    ...(targetObj.inputTransformer && {
+      InputTransformer: {
+        InputPathsMap: targetObj.inputTransformer.inputPathsMap,
+        InputTemplate: targetObj.inputTransformer.inputTemplate,
+      },
+    }),
+  };
+}
+
+module.exports = { generateTargetId, generatePolicyName, buildInputOptions };


### PR DESCRIPTION
Closes #759

## Summary
- Add `notificationStrategies/` with one module per target type (`sns`, `sqs`, `kinesis`, `firehose`, `lambda`, `stepFunctions`), each exporting `compileTarget` and `compilePermission` — mirroring the existing `iamStrategies/` pattern
- Extract shared utilities (`generateTargetId`, `generatePolicyName`, `buildInputOptions`) into `utils.js`
- Replace if/else dispatch chains in `compileNotifications.js` with a Map registry + `getStrategy()` lookup

## Test plan
- [ ] All 17 new strategy unit tests pass
- [ ] All 17 existing `compileNotifications` integration tests pass
- [ ] Full suite passes
- [ ] No changes to plugin configuration or public API

Part of #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)