### PR TITLE
refactor(events): extract shared input validator and IAM role factory

### DIFF
--- a/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.js
+++ b/lib/deploy/events/cloudWatchEvent/compileCloudWatchEventEvents.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const BbPromise = require('bluebird');
+const { validateEventInput, buildIamRole } = require('../eventUtils');
 
 module.exports = {
   compileCloudWatchEventEvents() {
@@ -62,14 +63,12 @@ module.exports = {
                 })
                 : undefined;
 
-              if ([Input, InputPath, InputTransformer].filter(Boolean).length > 1) {
-                const errorMessage = [
-                  'You can\'t set input, inputPath and inputTransformer properties at the',
-                  'same time for cloudwatch events.',
-                  'Please check the AWS docs for more info',
-                ].join('');
-                throw new this.serverless.classes.Error(errorMessage);
-              }
+              validateEventInput(
+                Input,
+                InputPath,
+                InputTransformer,
+                this.serverless.classes.Error,
+              );
 
               if (Input && typeof Input === 'object') {
                 Input = JSON.stringify(Input);
@@ -137,45 +136,6 @@ module.exports = {
               }
             `;
 
-            let iamRoleTemplate = `
-            {
-              "Type": "AWS::IAM::Role",
-              "Properties": {
-                "AssumeRolePolicyDocument": {
-                  "Version": "2012-10-17",
-                  "Statement": [
-                    {
-                      "Effect": "Allow",
-                      "Principal": {
-                        "Service": "events.amazonaws.com"
-                      },
-                      "Action": "sts:AssumeRole"
-                    }
-                  ]
-                },
-                "Policies": [
-                  {
-                    "PolicyName": "${policyName}",
-                    "PolicyDocument": {
-                      "Version": "2012-10-17",
-                      "Statement": [
-                        {
-                          "Effect": "Allow",
-                          "Action": [
-                            "states:StartExecution"
-                          ],
-                          "Resource": {
-                            "Ref": "${stateMachineLogicalId}"
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            }
-            `;
-
             const newCloudWatchEventRuleObject = {
               [cloudWatchLogicalId]: JSON.parse(cloudWatchEventRuleTemplate),
             };
@@ -183,18 +143,12 @@ module.exports = {
             const objectsToMerge = [newCloudWatchEventRuleObject];
 
             if (!IamRole) {
+              const iamRole = buildIamRole('events.amazonaws.com', policyName, stateMachineLogicalId);
               const rolePath = _.get(this.serverless.service, 'provider.iam.role.path');
               if (rolePath) {
-                const jsonIamRole = JSON.parse(iamRoleTemplate);
-                jsonIamRole.Properties.Path = rolePath;
-                iamRoleTemplate = JSON.stringify(jsonIamRole);
+                iamRole.Properties.Path = rolePath;
               }
-
-              const newPermissionObject = {
-                [cloudWatchIamRoleLogicalId]: JSON.parse(iamRoleTemplate),
-              };
-
-              objectsToMerge.push(newPermissionObject);
+              objectsToMerge.push({ [cloudWatchIamRoleLogicalId]: iamRole });
             }
 
             _.merge(

--- a/lib/deploy/events/eventUtils.js
+++ b/lib/deploy/events/eventUtils.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Validates that at most one of Input, InputPath, InputTransformer is set.
+ * Throws a Serverless error if more than one is set simultaneously.
+ */
+function validateEventInput(Input, InputPath, InputTransformer, ServerlessError) {
+  if ([Input, InputPath, InputTransformer].filter(Boolean).length > 1) {
+    throw new ServerlessError(
+      "You can't set input, inputPath and inputTransformer properties at the "
+      + 'same time for events. Please check the AWS docs for more info',
+    );
+  }
+}
+
+/**
+ * Builds a CloudFormation IAM Role resource for events/scheduler → Step Functions execution.
+ * @param {string} principalService - e.g. 'events.amazonaws.com' or 'scheduler.amazonaws.com'
+ * @param {string} policyName
+ * @param {string} stateMachineLogicalId
+ * @returns {object} CloudFormation IAM Role resource object
+ */
+function buildIamRole(principalService, policyName, stateMachineLogicalId) {
+  return {
+    Type: 'AWS::IAM::Role',
+    Properties: {
+      AssumeRolePolicyDocument: {
+        Version: '2012-10-17',
+        Statement: [{
+          Effect: 'Allow',
+          Principal: { Service: principalService },
+          Action: 'sts:AssumeRole',
+        }],
+      },
+      Policies: [{
+        PolicyName: policyName,
+        PolicyDocument: {
+          Version: '2012-10-17',
+          Statement: [{
+            Effect: 'Allow',
+            Action: ['states:StartExecution'],
+            Resource: { Ref: stateMachineLogicalId },
+          }],
+        },
+      }],
+    },
+  };
+}
+
+module.exports = { validateEventInput, buildIamRole };

--- a/lib/deploy/events/eventUtils.test.js
+++ b/lib/deploy/events/eventUtils.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const expect = require('chai').expect;
+const { validateEventInput, buildIamRole } = require('./eventUtils');
+
+class TestError extends Error {}
+
+describe('eventUtils', () => {
+  describe('#validateEventInput()', () => {
+    it('should not throw when only Input is set', () => {
+      expect(() => validateEventInput('value', undefined, undefined, TestError)).to.not.throw();
+    });
+
+    it('should not throw when only InputPath is set', () => {
+      expect(() => validateEventInput(undefined, '$.path', undefined, TestError)).to.not.throw();
+    });
+
+    it('should not throw when only InputTransformer is set', () => {
+      expect(() => validateEventInput(undefined, undefined, { inputTemplate: 'tpl' }, TestError)).to.not.throw();
+    });
+
+    it('should not throw when none are set', () => {
+      expect(() => validateEventInput(undefined, undefined, undefined, TestError)).to.not.throw();
+    });
+
+    it('should throw when Input and InputPath are both set', () => {
+      expect(() => validateEventInput('value', '$.path', undefined, TestError)).to.throw(TestError);
+    });
+
+    it('should throw when Input and InputTransformer are both set', () => {
+      expect(() => validateEventInput('value', undefined, { inputTemplate: 'tpl' }, TestError)).to.throw(TestError);
+    });
+
+    it('should throw when all three are set', () => {
+      expect(() => validateEventInput('value', '$.path', { inputTemplate: 'tpl' }, TestError)).to.throw(TestError);
+    });
+  });
+
+  describe('#buildIamRole()', () => {
+    it('should return a CF IAM Role with the given principal service', () => {
+      const result = buildIamRole('events.amazonaws.com', 'my-policy', 'MyStateMachine');
+      expect(result.Type).to.equal('AWS::IAM::Role');
+      expect(result.Properties.AssumeRolePolicyDocument.Statement[0].Principal.Service)
+        .to.equal('events.amazonaws.com');
+    });
+
+    it('should set the policy name and state machine resource ref', () => {
+      const result = buildIamRole('scheduler.amazonaws.com', 'my-policy', 'MyStateMachine');
+      const policy = result.Properties.Policies[0];
+      expect(policy.PolicyName).to.equal('my-policy');
+      expect(policy.PolicyDocument.Statement[0].Resource).to.deep.equal({ Ref: 'MyStateMachine' });
+      expect(policy.PolicyDocument.Statement[0].Action).to.deep.equal(['states:StartExecution']);
+    });
+
+    it('should use the given principal service for scheduler', () => {
+      const result = buildIamRole('scheduler.amazonaws.com', 'my-policy', 'MyStateMachine');
+      expect(result.Properties.AssumeRolePolicyDocument.Statement[0].Principal.Service)
+        .to.equal('scheduler.amazonaws.com');
+    });
+  });
+});

--- a/lib/deploy/events/schedule/compileScheduledEvents.js
+++ b/lib/deploy/events/schedule/compileScheduledEvents.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const BbPromise = require('bluebird');
+const { validateEventInput, buildIamRole } = require('../eventUtils');
 
 const METHOD_SCHEDULER = 'scheduler';
 const METHOD_EVENT_BUS = 'eventBus';
@@ -63,15 +64,12 @@ module.exports = {
                 })
                 : undefined;
 
-              if ([Input, InputPath, InputTransformer].filter(Boolean).length > 1) {
-                const errorMessage = [
-                  'You can\'t set both input & inputPath properties at the',
-                  'same time for schedule events.',
-                  'Please check the AWS docs for more info',
-                ].join('');
-                throw new this.serverless.classes
-                  .Error(errorMessage);
-              }
+              validateEventInput(
+                Input,
+                InputPath,
+                InputTransformer,
+                this.serverless.classes.Error,
+              );
 
               if (Input && typeof Input === 'object') {
                 Input = JSON.stringify(Input);
@@ -151,7 +149,6 @@ module.exports = {
               `;
 
             let scheduleTemplate;
-            let iamRoleTemplate;
             // If condition for the event bridge schedular and it define
             // resource template and iamrole for the same
             if (method === METHOD_SCHEDULER) {
@@ -173,43 +170,6 @@ module.exports = {
                 }
               }
             }`;
-
-              iamRoleTemplate = `{
-            "Type": "AWS::IAM::Role",
-            "Properties": {
-              "AssumeRolePolicyDocument": {
-                "Version": "2012-10-17",
-                "Statement": [
-                  {
-                    "Effect": "Allow",
-                    "Principal": {
-                        "Service": "scheduler.amazonaws.com"
-                    },
-                    "Action": "sts:AssumeRole"
-                  }
-                ]
-              },
-              "Policies": [
-                {
-                  "PolicyName": "${policyName}",
-                  "PolicyDocument": {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                      {
-                        "Effect": "Allow",
-                        "Action": [
-                          "states:StartExecution"
-                        ],
-                        "Resource": {
-                          "Ref": "${stateMachineLogicalId}"
-                        }
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          }`;
             } else {
               // else condition for the event rule and
               // it define resource template and iamrole for the same
@@ -234,54 +194,19 @@ module.exports = {
                   }]
                 }
               }`;
-              iamRoleTemplate = `{
-              "Type": "AWS::IAM::Role",
-              "Properties": {
-                "AssumeRolePolicyDocument": {
-                  "Version": "2012-10-17",
-                  "Statement": [
-                    {
-                      "Effect": "Allow",
-                      "Principal": {
-                        "Service": "events.amazonaws.com"
-                      },
-                      "Action": "sts:AssumeRole"
-                    }
-                  ]
-                },
-                "Policies": [
-                  {
-                    "PolicyName": "${policyName}",
-                    "PolicyDocument": {
-                      "Version": "2012-10-17",
-                      "Statement": [
-                        {
-                          "Effect": "Allow",
-                          "Action": [
-                            "states:StartExecution"
-                          ],
-                          "Resource": {
-                            "Ref": "${stateMachineLogicalId}"
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            }`;
-            }
-            if (permissionsBoundary) {
-              const jsonIamRole = JSON.parse(iamRoleTemplate);
-              jsonIamRole.Properties.PermissionsBoundary = permissionsBoundary;
-              iamRoleTemplate = JSON.stringify(jsonIamRole);
             }
 
+            const principalService = method === METHOD_SCHEDULER
+              ? 'scheduler.amazonaws.com'
+              : 'events.amazonaws.com';
+            const iamRole = buildIamRole(principalService, policyName, stateMachineLogicalId);
+
             const rolePath = _.get(service, 'provider.iam.role.path');
+            if (permissionsBoundary) {
+              iamRole.Properties.PermissionsBoundary = permissionsBoundary;
+            }
             if (rolePath) {
-              const jsonIamRole = JSON.parse(iamRoleTemplate);
-              jsonIamRole.Properties.Path = rolePath;
-              iamRoleTemplate = JSON.stringify(jsonIamRole);
+              iamRole.Properties.Path = rolePath;
             }
 
             const newScheduleObject = {
@@ -289,7 +214,7 @@ module.exports = {
             };
 
             const newPermissionObject = event.schedule.role ? {} : {
-              [scheduleIamRoleLogicalId]: JSON.parse(iamRoleTemplate),
+              [scheduleIamRoleLogicalId]: iamRole,
             };
 
             _.merge(


### PR DESCRIPTION
Closes #760

## Summary
- Add `eventUtils.js` with `validateEventInput` (replaces duplicate mutual-exclusivity checks in schedule and cloudwatch compilers) and `buildIamRole` (replaces duplicate JSON string IAM role templates, parameterised by principal service)
- Eliminate `JSON.parse`/`stringify` round-trips — IAM role is now a plain JS object mutated directly for `permissionsBoundary` and `rolePath`

## Test plan
- [ ] 10 new `eventUtils` unit tests pass
- [ ] All 67 existing schedule + cloudwatch event tests pass
- [ ] Full suite passes
- [ ] No changes to plugin configuration or public API

Part of #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)